### PR TITLE
[DFT][cuFFT] Fix "Invalid strides" for shapes with a unit last dimension (#631)

### DIFF
--- a/src/dft/backends/cufft/commit.cpp
+++ b/src/dft/backends/cufft/commit.cpp
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <algorithm>
+#include <iterator>
 #include <optional>
 
 #include "oneapi/math/exceptions.hpp"
@@ -160,9 +161,20 @@ public:
         offset_bwd_in = stride_vecs.offset_bwd_in;
         offset_bwd_out = stride_vecs.offset_bwd_out;
 
-        // cufft ignores the first value in inembed and onembed, so there is no harm in putting offset there
-        auto a_min = std::min_element(stride_vecs.vec_a.begin() + 1, stride_vecs.vec_a.end());
-        auto b_min = std::min_element(stride_vecs.vec_b.begin() + 1, stride_vecs.vec_b.end());
+        // cufft ignores the first value in inembed and onembed, so there is no harm in putting offset there.
+        // Find the dimension with the smallest stride (used as the cuFFT istride/ostride). When several
+        // dimensions share the smallest stride - which happens when a dimension has extent 1 and hence the
+        // same stride as its neighbour - prefer the innermost (last) dimension. Searching in reverse makes
+        // std::min_element resolve such ties to the highest index, avoiding a spurious dimension swap below
+        // that would otherwise reject valid transforms (e.g. shapes like {3,1}). See issue #631.
+        auto a_min = std::min_element(std::make_reverse_iterator(stride_vecs.vec_a.end()),
+                                      std::make_reverse_iterator(stride_vecs.vec_a.begin() + 1))
+                         .base() -
+                     1;
+        auto b_min = std::min_element(std::make_reverse_iterator(stride_vecs.vec_b.end()),
+                                      std::make_reverse_iterator(stride_vecs.vec_b.begin() + 1))
+                         .base() -
+                     1;
         if constexpr (dom == dft::domain::REAL) {
             if ((a_min != stride_vecs.vec_a.begin() + rank) ||
                 (b_min != stride_vecs.vec_b.begin() + rank)) {
@@ -180,6 +192,8 @@ public:
         }
         const int a_stride = static_cast<int>(*a_min);
         const int b_stride = static_cast<int>(*b_min);
+        // Capture the position before erasing, as the iterator is invalidated by erase.
+        const auto a_min_idx = a_min - stride_vecs.vec_a.begin();
         stride_vecs.vec_a.erase(a_min);
         stride_vecs.vec_b.erase(b_min);
         int fwd_istride = a_stride;
@@ -188,9 +202,9 @@ public:
             stride_api_choice == dft::detail::stride_api::FB_STRIDES ? b_stride : a_stride;
         int bwd_ostride =
             stride_api_choice == dft::detail::stride_api::FB_STRIDES ? a_stride : b_stride;
-        if (a_min - stride_vecs.vec_a.begin() != rank) {
+        if (a_min_idx != rank) {
             // swap dimensions to have the last one have the smallest stride
-            std::swap(n_copy[a_min - stride_vecs.vec_a.begin() - 1], n_copy[rank - 1]);
+            std::swap(n_copy[a_min_idx - 1], n_copy[rank - 1]);
         }
         for (int i = 1; i < rank; i++) {
             if ((stride_vecs.vec_a[i] % a_stride != 0) || (stride_vecs.vec_b[i] % b_stride != 0)) {


### PR DESCRIPTION
## Summary

Fixes #631.

`oneapi::math::dft` on the cuFFT backend throws `dft/backends/cufft/commit: Invalid strides` for multi-dimensional transforms whose **last dimension has extent 1** (e.g. `{3,1}`, `{2,1}`, `{5,1}`, `{2,3,1}`). The same descriptors work on the Intel (MKL) backends, and the equivalent transform works when calling cuFFT directly.

### Root cause

In `src/dft/backends/cufft/commit.cpp`, the backend uses `std::min_element` to find the dimension with the smallest stride (which becomes the cuFFT `istride`/`ostride`, i.e. the innermost dimension).

When a dimension has extent 1, its default stride ties with its neighbour's stride. `std::min_element` returns the **first** element among ties, so an **outer** dimension is mis-identified as the innermost one. This triggers the dimension-swap heuristic, producing a dimension/stride ordering that the `check_stride_validity()` pre-check then rejects — computing `inner_n (e.g. 3) <= inner_stride (1)` as false for both directions and throwing `Invalid strides`. The underlying `cufftPlanMany` call that would have been issued is actually valid.

There is also latent **undefined behaviour**: the swap logic computes the selected index from `a_min` *after* `vec_a.erase(a_min)` has invalidated that iterator. This is why the failure is compiler-dependent (it reproduces with `icpx`, but a recent open-source DPC++/clang build happens to take a different, passing path).

### Fix

- Search for the smallest stride in **reverse**, so ties resolve to the **innermost (highest-index)** dimension. This avoids the spurious dimension swap and lets valid transforms through.
- Capture the selected stride index **before** `erase()`, removing the invalidated-iterator UB.

No behavioural change for shapes without unit dimensions: for strictly decreasing default strides the reverse search selects the same (last) element as before.

## Test plan

Validated end-to-end on an NVIDIA sm_103 device, CUDA 13.2 / cuFFT 12.2, using an open-source DPC++ toolchain (intel/llvm nightly with the CUDA backend). Built oneMath with `-DENABLE_CUFFT_BACKEND=ON -DTARGET_DOMAINS=dft`.

With the fix, the reproducer from #631 and related shapes all pass:

```
shape {3,1}   : OK -> [(3,0) (0,0) (0,0)]
shape {2,1}   : OK -> [(2,0) (0,0)]
shape {5,1}   : OK -> [(5,0) (0,0) (0,0) (0,0) (0,0)]
shape {2,3,1} : OK -> [(6,0) ...]
shape {3,4}   : OK   (regression check)
shape {2,3,4} : OK   (regression check)
shape {8}     : OK   (regression check)
```

- [x] Confirmed direct cuFFT (`cufftPlan2d(3,1)` and the exact `cufftPlanMany` params oneMath generates) succeed on the B300 — the failure is in the pre-check, not cuFFT.
- [x] Standalone comparison of the stride algorithm: original logic REJECTS `{3,1}`, `{2,1}`, `{5,1}`, `{2,3,1}`; fixed logic ACCEPTS them; regression shapes unchanged.
- [x] End-to-end build + run on B300: all shapes above pass.
- [ ] CI: DFT cuFFT functional tests.

Suggestion for maintainers: consider adding a DFT test case covering shapes with a unit last dimension to guard against regressions.
