### PR TITLE
[CMake] Accept legacy 'hipsycl' as deprecated alias for 'adaptivecpp'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,12 @@ else()
   # Find necessary packages
   if(ONEMATH_SYCL_IMPLEMENTATION)
     string( TOLOWER "${ONEMATH_SYCL_IMPLEMENTATION}" ONEMATH_SYCL_IMPLEMENTATION)
+    # hipSYCL was renamed to AdaptiveCpp. Accept the legacy value as a
+    # deprecated alias so existing build scripts keep working.
+    if (ONEMATH_SYCL_IMPLEMENTATION STREQUAL "hipsycl")
+      message(WARNING "ONEMATH_SYCL_IMPLEMENTATION=hipsycl is deprecated: hipSYCL has been renamed to AdaptiveCpp. Treating it as 'adaptivecpp'. Please use -DONEMATH_SYCL_IMPLEMENTATION=adaptivecpp instead.")
+      set(ONEMATH_SYCL_IMPLEMENTATION "adaptivecpp")
+    endif()
     if (ONEMATH_SYCL_IMPLEMENTATION STREQUAL "adaptivecpp")
       message(STATUS "Looking for AdaptiveCpp")
       find_package(AdaptiveCpp CONFIG REQUIRED)


### PR DESCRIPTION
## Summary

Addresses #711.

hipSYCL was renamed to AdaptiveCpp, and #699 updated `ONEMATH_SYCL_IMPLEMENTATION` (and all internal references / docs) to use `adaptivecpp`. As a result, users following older instructions or scripts that pass `-DONEMATH_SYCL_IMPLEMENTATION=hipsycl` now hit a fatal error:

```
SYCL implementation hipsycl is not known
```

This PR accepts the legacy `hipsycl` value as a deprecated alias for `adaptivecpp`, emitting a deprecation warning that points users to the new value, so existing build scripts keep working:

```cmake
if (ONEMATH_SYCL_IMPLEMENTATION STREQUAL "hipsycl")
  message(WARNING "ONEMATH_SYCL_IMPLEMENTATION=hipsycl is deprecated: ... Treating it as 'adaptivecpp'. Please use -DONEMATH_SYCL_IMPLEMENTATION=adaptivecpp instead.")
  set(ONEMATH_SYCL_IMPLEMENTATION "adaptivecpp")
endif()
```

Note: the original report (v0.9) predates #699; on current `develop` the docs and CMake already agree on `adaptivecpp`. This change only adds backward compatibility for the old spelling.

## Test plan

- [x] `-DONEMATH_SYCL_IMPLEMENTATION=adaptivecpp` unchanged.
- [x] `-DONEMATH_SYCL_IMPLEMENTATION=hipsycl` (and `hipSYCL`, via existing `TOLOWER`) now maps to AdaptiveCpp with a deprecation warning instead of failing.
- [x] Unknown values still produce the existing fatal error.
