### PR TITLE
Add compile-time dispatching examples for generic BLAS and portFFT backends

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,12 @@ oneMath offers examples with the following routines:
 
 Each routine has one run-time dispatching example and one compile-time dispatching example (which uses both mklcpu and cuda backends), located in `example/<$domain>/run_time_dispatching` and `example/<$domain>/compile_time_dispatching` subfolders, respectively.
 
+In addition, the SYCL-only backends provide standalone compile-time dispatching examples that run on a single SYCL device:
+- blas: `level3/gemm_usm_generic` (built when `ENABLE_GENERIC_BLAS_BACKEND` is enabled)
+- dft: `complex_fwd_usm_portfft` (built when `ENABLE_PORTFFT_BACKEND` is enabled)
+
+These are useful for validating the generic BLAS and portFFT backends, which cannot be combined with any other backend.
+
 To build examples, use cmake build option `-DBUILD_EXAMPLES=true`.
 Compile_time_dispatching will be built if `-DBUILD_EXAMPLES=true` and cuda backend is enabled, because the compile-time dispatching example runs on both mklcpu and cuda backends.
 Run_time_dispatching will be built if `-DBUILD_EXAMPLES=true` and `-DBUILD_SHARED_LIBS=true`.
@@ -179,6 +185,57 @@ Running with single precision real data type on:
                             [ ...
 
 BLAS GEMM USM example ran OK on MKLCPU and CUBLAS
+
+```
+
+Compile-time dispatching example with the SYCL-only generic BLAS backend
+```
+$ ./bin/example_blas_gemm_usm_generic
+
+########################################################################
+# General Matrix-Matrix Multiplication using Unified Shared Memory Example:
+#
+# C = alpha * A * B + beta * C
+#
+# where A, B and C are general dense matrices and alpha, beta are
+# floating point type precision scalars.
+#
+# Using apis:
+#   gemm
+#
+# Using single precision (float) data type
+#
+# Running on a SYCL device with the generic BLAS backend
+#
+########################################################################
+
+Running BLAS GEMM USM example on GPU device.
+Device name is: Intel(R) Arc(TM) B580 Graphics
+Running with single precision real data type:
+
+                GEMM parameters:
+                        transA = trans, transB = nontrans
+                        m = 45, n = 98, k = 67
+                        lda = 103, ldB = 105, ldC = 106
+                        alpha = 2, beta = 3
+
+                Outputting 2x2 block of A,B,C matrices:
+
+                        A = [ 0.340188, 0.260249, ...
+                            [ -0.105617, 0.0125354, ...
+                            [ ...
+
+
+                        B = [ -0.326421, -0.192968, ...
+                            [ 0.363891, 0.251295, ...
+                            [ ...
+
+
+                        C = [ 0.00698781, 0.525862, ...
+                            [ 0.585167, 1.59017, ...
+                            [ ...
+
+BLAS GEMM USM example ran OK on the generic backend
 
 ```
  
@@ -478,6 +535,33 @@ Running with single precision real data type:
 DFT example run_time dispatch
 Unsupported Configuration:
 	oneMath: dft/backends/portfft/commit: function is not implemented REAL domain is unsupported
+```
+
+Compile-time dispatching example with the SYCL-only portFFT backend
+
+(Note that the portFFT backend only supports the COMPLEX domain.)
+
+```none
+$ ./bin/example_dft_complex_fwd_usm_portfft
+
+########################################################################
+# Complex in-place forward transform for USM API's example:
+#
+# Using APIs:
+#   Compile-time dispatch API
+#   USM forward complex in-place
+#
+# Using single precision (float) data type
+#
+# Running on a SYCL device with the portFFT backend.
+#
+########################################################################
+
+Running DFT complex forward example on GPU device
+Device name is: Intel(R) Arc(TM) B580 Graphics
+Using compile-time dispatch API with portFFT.
+Running with single precision real data type:
+DFT Complex USM example ran OK on portFFT
 ```
 
 ## sparse_blas

--- a/examples/blas/compile_time_dispatching/level3/CMakeLists.txt
+++ b/examples/blas/compile_time_dispatching/level3/CMakeLists.txt
@@ -17,31 +17,54 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-# The example is written for the MKLCPU and CUBLAS backends
-if(NOT (ENABLE_MKLCPU_BACKEND AND ENABLE_CUBLAS_BACKEND))
-  return()
+# The MKLCPU + CUBLAS example is written for the MKLCPU and CUBLAS backends
+if(ENABLE_MKLCPU_BACKEND AND ENABLE_CUBLAS_BACKEND)
+  set(EXAMPLE_TARGET example_blas_gemm_usm_mklcpu_cublas)
+
+  # External applications should use find_package or FetchContent to include oneMath first.
+  # See https://github.com/uxlfoundation/oneMath/blob/develop/docs/using_onemath_with_cmake.rst
+
+  # Create a CMake target with one source file
+  add_executable(${EXAMPLE_TARGET} gemm_usm_mklcpu_cublas.cpp)
+
+  # Linking against onemath_blas_mklcpu and onemath_blas_cublas in CMake will add the required include directories and dependencies.
+  # One can also link against `onemath_blas` to link against all the blas backends built.
+  # These targets should only be used for compile-time dispatching.
+  target_link_libraries(${EXAMPLE_TARGET} PUBLIC
+    onemath_blas_mklcpu
+    onemath_blas_cublas
+  )
+
+  # Include directories specific to the examples
+  target_include_directories(${EXAMPLE_TARGET} PUBLIC
+    ${PROJECT_SOURCE_DIR}/examples/include
+  )
+
+  # Register example as ctest
+  add_test(NAME blas/EXAMPLE/CT/gemm_usm_mklcpu_cublas COMMAND ${EXAMPLE_TARGET})
 endif()
 
-set(EXAMPLE_TARGET example_blas_gemm_usm_mklcpu_cublas)
+# The generic example is written for the SYCL-only generic BLAS backend
+if(ENABLE_GENERIC_BLAS_BACKEND)
+  set(EXAMPLE_TARGET example_blas_gemm_usm_generic)
 
-# External applications should use find_package or FetchContent to include oneMath first.
-# See https://github.com/uxlfoundation/oneMath/blob/develop/docs/using_onemath_with_cmake.rst
+  # External applications should use find_package or FetchContent to include oneMath first.
+  # See https://github.com/uxlfoundation/oneMath/blob/develop/docs/using_onemath_with_cmake.rst
 
-# Create a CMake target with one source file
-add_executable(${EXAMPLE_TARGET} gemm_usm_mklcpu_cublas.cpp)
+  # Create a CMake target with one source file
+  add_executable(${EXAMPLE_TARGET} gemm_usm_generic.cpp)
 
-# Linking against onemath_blas_mklcpu and onemath_blas_cublas in CMake will add the required include directories and dependencies.
-# One can also link against `onemath_blas` to link against all the blas backends built.
-# These targets should only be used for compile-time dispatching.
-target_link_libraries(${EXAMPLE_TARGET} PUBLIC
-  onemath_blas_mklcpu
-  onemath_blas_cublas
-)
+  # Linking against onemath_blas_generic in CMake will add the required include directories and dependencies.
+  # This target should only be used for compile-time dispatching.
+  target_link_libraries(${EXAMPLE_TARGET} PUBLIC
+    onemath_blas_generic
+  )
 
-# Include directories specific to the examples
-target_include_directories(${EXAMPLE_TARGET} PUBLIC
-  ${PROJECT_SOURCE_DIR}/examples/include
-)
+  # Include directories specific to the examples
+  target_include_directories(${EXAMPLE_TARGET} PUBLIC
+    ${PROJECT_SOURCE_DIR}/examples/include
+  )
 
-# Register example as ctest
-add_test(NAME blas/EXAMPLE/CT/gemm_usm_mklcpu_cublas COMMAND ${EXAMPLE_TARGET})
+  # Register example as ctest
+  add_test(NAME blas/EXAMPLE/CT/gemm_usm_generic COMMAND ${EXAMPLE_TARGET})
+endif()

--- a/examples/blas/compile_time_dispatching/level3/gemm_usm_generic.cpp
+++ b/examples/blas/compile_time_dispatching/level3/gemm_usm_generic.cpp
@@ -1,0 +1,243 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+/*
+*
+*  Content:
+*       This example demonstrates use of DPCPP API oneapi::math::blas::gemm
+*       using unified shared memory to perform General Matrix-Matrix
+*       Multiplication on a SYCL device (CPU, GPU) using the SYCL-only
+*       "generic" BLAS backend with compile-time dispatching.
+*
+*       C = alpha * op(A) * op(B) + beta * C
+*
+*       where op() is defined by one of oneapi::math::transpose::{nontrans,trans,conjtrans}
+*
+*
+*       This example demonstrates only single precision (float) data type for
+*       gemm matrix data
+*
+*
+*******************************************************************************/
+
+// stl includes
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+// oneMath/SYCL includes
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+#include "oneapi/math.hpp"
+
+// local includes
+#include "example_helper.hpp"
+
+//
+// Main example for Gemm consisting of
+// initialization of A, B and C matrices as well as
+// scalars alpha and beta.  Then the product
+//
+// C = alpha * op(A) * op(B) + beta * C
+//
+// is performed and finally the results are post processed.
+//
+void run_gemm_example(const sycl::device& dev) {
+    //
+    // Initialize data for Gemm
+    //
+    // C = alpha * op(A) * op(B)  + beta * C
+    //
+    oneapi::math::transpose transA = oneapi::math::transpose::trans;
+    oneapi::math::transpose transB = oneapi::math::transpose::nontrans;
+
+    // matrix data sizes
+    int m = 45;
+    int n = 98;
+    int k = 67;
+
+    // leading dimensions of data
+    int ldA = 103;
+    int ldB = 105;
+    int ldC = 106;
+    int sizea = (transA == oneapi::math::transpose::nontrans) ? ldA * k : ldA * m;
+    int sizeb = (transB == oneapi::math::transpose::nontrans) ? ldB * n : ldB * k;
+    int sizec = ldC * n;
+
+    // set scalar fp values
+    float alpha = set_fp_value(float(2.0), float(-0.5));
+    float beta = set_fp_value(float(3.0), float(-1.5));
+
+    // Catch asynchronous exceptions
+    auto exception_handler = [](sycl::exception_list exceptions) {
+        for (std::exception_ptr const& e : exceptions) {
+            try {
+                std::rethrow_exception(e);
+            }
+            catch (sycl::exception const& e) {
+                std::cerr << "Caught asynchronous SYCL exception during GEMM:" << std::endl;
+                std::cerr << "\t" << e.what() << std::endl;
+            }
+        }
+        std::exit(2);
+    };
+
+    // create execution queue
+    sycl::queue main_queue(dev, exception_handler);
+    sycl::event gemm_done;
+    sycl::context cxt = main_queue.get_context();
+
+    // allocate matrix on host
+    std::vector<float> A(sizea);
+    std::vector<float> B(sizeb);
+    std::vector<float> C(sizec);
+    std::fill(A.begin(), A.end(), 0);
+    std::fill(B.begin(), B.end(), 0);
+    std::fill(C.begin(), C.end(), 0);
+
+    rand_matrix(A, transA, m, k, ldA);
+    rand_matrix(B, transB, k, n, ldB);
+    rand_matrix(C, oneapi::math::transpose::nontrans, m, n, ldC);
+
+    // allocate memory on device
+    auto dev_A = sycl::malloc_device<float>(sizea * sizeof(float), main_queue);
+    auto dev_B = sycl::malloc_device<float>(sizeb * sizeof(float), main_queue);
+    auto dev_C = sycl::malloc_device<float>(sizec * sizeof(float), main_queue);
+    if (!dev_A || !dev_B || !dev_C) {
+        throw std::runtime_error("Failed to allocate USM memory.");
+    }
+
+    // copy data from host to device
+    main_queue.memcpy(dev_A, A.data(), sizea * sizeof(float)).wait();
+    main_queue.memcpy(dev_B, B.data(), sizeb * sizeof(float)).wait();
+    main_queue.memcpy(dev_C, C.data(), sizec * sizeof(float)).wait();
+
+    //
+    // Execute Gemm
+    //
+    // add oneapi::math::blas::gemm to execution queue using the generic backend
+    gemm_done = oneapi::math::blas::column_major::gemm(
+        oneapi::math::backend_selector<oneapi::math::backend::generic>{ main_queue }, transA, transB,
+        m, n, k, alpha, dev_A, ldA, dev_B, ldB, beta, dev_C, ldC);
+
+    // Wait until calculations are done
+    gemm_done.wait_and_throw();
+
+    //
+    // Post Processing
+    //
+    // copy data from device back to host
+    main_queue.memcpy(C.data(), dev_C, sizec * sizeof(float)).wait_and_throw();
+
+    std::cout << "\n\t\tGEMM parameters:" << std::endl;
+    std::cout << "\t\t\ttransA = "
+              << (transA == oneapi::math::transpose::nontrans
+                      ? "nontrans"
+                      : (transA == oneapi::math::transpose::trans ? "trans" : "conjtrans"))
+              << ", transB = "
+              << (transB == oneapi::math::transpose::nontrans
+                      ? "nontrans"
+                      : (transB == oneapi::math::transpose::trans ? "trans" : "conjtrans"))
+              << std::endl;
+    std::cout << "\t\t\tm = " << m << ", n = " << n << ", k = " << k << std::endl;
+    std::cout << "\t\t\tlda = " << ldA << ", ldB = " << ldB << ", ldC = " << ldC << std::endl;
+    std::cout << "\t\t\talpha = " << alpha << ", beta = " << beta << std::endl;
+
+    std::cout << "\n\t\tOutputting 2x2 block of A,B,C matrices:" << std::endl;
+
+    // output the top 2x2 block of A matrix
+    print_2x2_matrix_values(A.data(), ldA, "A");
+
+    // output the top 2x2 block of B matrix
+    print_2x2_matrix_values(B.data(), ldB, "B");
+
+    // output the top 2x2 block of C matrix
+    print_2x2_matrix_values(C.data(), ldC, "C");
+
+    sycl::free(dev_C, main_queue);
+    sycl::free(dev_B, main_queue);
+    sycl::free(dev_A, main_queue);
+}
+
+//
+// Description of example setup, apis used and supported floating point type precisions
+//
+void print_example_banner() {
+    std::cout << "" << std::endl;
+    std::cout << "########################################################################"
+              << std::endl;
+    std::cout << "# General Matrix-Matrix Multiplication using Unified Shared Memory Example: "
+              << std::endl;
+    std::cout << "# " << std::endl;
+    std::cout << "# C = alpha * A * B + beta * C" << std::endl;
+    std::cout << "# " << std::endl;
+    std::cout << "# where A, B and C are general dense matrices and alpha, beta are" << std::endl;
+    std::cout << "# floating point type precision scalars." << std::endl;
+    std::cout << "# " << std::endl;
+    std::cout << "# Using apis:" << std::endl;
+    std::cout << "#   gemm" << std::endl;
+    std::cout << "# " << std::endl;
+    std::cout << "# Using single precision (float) data type" << std::endl;
+    std::cout << "# " << std::endl;
+    std::cout << "# Running on a SYCL device with the generic BLAS backend" << std::endl;
+    std::cout << "# " << std::endl;
+    std::cout << "########################################################################"
+              << std::endl;
+    std::cout << std::endl;
+}
+
+//
+// Main entry point for example.
+//
+int main(int argc, char** argv) {
+    print_example_banner();
+
+    try {
+        sycl::device dev = sycl::device();
+
+        if (dev.is_gpu()) {
+            std::cout << "Running BLAS GEMM USM example on GPU device." << std::endl;
+        }
+        else {
+            std::cout << "Running BLAS GEMM USM example on CPU device." << std::endl;
+        }
+        std::cout << "Device name is: " << dev.get_info<sycl::info::device::name>() << std::endl;
+        std::cout << "Running with single precision real data type:" << std::endl;
+
+        run_gemm_example(dev);
+        std::cout << "BLAS GEMM USM example ran OK on the generic backend" << std::endl;
+    }
+    catch (sycl::exception const& e) {
+        std::cerr << "Caught synchronous SYCL exception during GEMM:" << std::endl;
+        std::cerr << "\t" << e.what() << std::endl;
+        std::cerr << "\tSYCL error code: " << e.code().value() << std::endl;
+        return 1;
+    }
+    catch (std::exception const& e) {
+        std::cerr << "Caught std::exception during GEMM:" << std::endl;
+        std::cerr << "\t" << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/examples/blas/compile_time_dispatching/level3/gemm_usm_generic.cpp
+++ b/examples/blas/compile_time_dispatching/level3/gemm_usm_generic.cpp
@@ -137,8 +137,8 @@ void run_gemm_example(const sycl::device& dev) {
     //
     // add oneapi::math::blas::gemm to execution queue using the generic backend
     gemm_done = oneapi::math::blas::column_major::gemm(
-        oneapi::math::backend_selector<oneapi::math::backend::generic>{ main_queue }, transA, transB,
-        m, n, k, alpha, dev_A, ldA, dev_B, ldB, beta, dev_C, ldC);
+        oneapi::math::backend_selector<oneapi::math::backend::generic>{ main_queue }, transA,
+        transB, m, n, k, alpha, dev_A, ldA, dev_B, ldB, beta, dev_C, ldC);
 
     // Wait until calculations are done
     gemm_done.wait_and_throw();

--- a/examples/dft/compile_time_dispatching/CMakeLists.txt
+++ b/examples/dft/compile_time_dispatching/CMakeLists.txt
@@ -17,35 +17,62 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-# The example is written for the MKLCPU and CUFFT backends
-if(NOT (ENABLE_MKLCPU_BACKEND AND ENABLE_CUFFT_BACKEND))
-  return()
+# The MKLCPU + cuFFT example is written for the MKLCPU and CUFFT backends
+if(ENABLE_MKLCPU_BACKEND AND ENABLE_CUFFT_BACKEND)
+  set(EXAMPLE_TARGET example_dft_complex_fwd_usm_mklcpu_cufft)
+
+  # External applications should use find_package or FetchContent to include oneMath first.
+  # See https://github.com/uxlfoundation/oneMath/blob/develop/docs/using_onemath_with_cmake.rst
+
+  # Create a CMake target with one source file
+  add_executable(${EXAMPLE_TARGET} complex_fwd_usm_mklcpu_cufft.cpp)
+
+  # Linking against onemath_dft_mklcpu and onemath_dft_cufft in CMake will add the required include directories and dependencies.
+  # One can also link against `onemath_dft` to link against all the dft backends built.
+  # These targets should only be used for compile-time dispatching.
+  target_link_libraries(${EXAMPLE_TARGET} PUBLIC
+    onemath_dft_mklcpu
+    onemath_dft_cufft
+  )
+
+  # Include directories specific to the examples
+  target_include_directories(${EXAMPLE_TARGET} PUBLIC
+    ${PROJECT_SOURCE_DIR}/examples/include
+  )
+
+  # Enable warnings
+  include(WarningsUtils)
+  target_link_libraries(${EXAMPLE_TARGET} PRIVATE onemath_warnings)
+
+  # Register example as ctest
+  add_test(NAME dft/EXAMPLE/CT/complex_fwd_usm_mklcpu_cufft COMMAND ${EXAMPLE_TARGET})
 endif()
 
-set(EXAMPLE_TARGET example_dft_complex_fwd_usm_mklcpu_cufft)
+# The portFFT example is written for the SYCL-only portFFT backend
+if(ENABLE_PORTFFT_BACKEND)
+  set(EXAMPLE_TARGET example_dft_complex_fwd_usm_portfft)
 
-# External applications should use find_package or FetchContent to include oneMath first.
-# See https://github.com/uxlfoundation/oneMath/blob/develop/docs/using_onemath_with_cmake.rst
+  # External applications should use find_package or FetchContent to include oneMath first.
+  # See https://github.com/uxlfoundation/oneMath/blob/develop/docs/using_onemath_with_cmake.rst
 
-# Create a CMake target with one source file
-add_executable(${EXAMPLE_TARGET} complex_fwd_usm_mklcpu_cufft.cpp)
+  # Create a CMake target with one source file
+  add_executable(${EXAMPLE_TARGET} complex_fwd_usm_portfft.cpp)
 
-# Linking against onemath_dft_mklcpu and onemath_dft_cufft in CMake will add the required include directories and dependencies.
-# One can also link against `onemath_dft` to link against all the dft backends built.
-# These targets should only be used for compile-time dispatching.
-target_link_libraries(${EXAMPLE_TARGET} PUBLIC
-  onemath_dft_mklcpu
-  onemath_dft_cufft
-)
+  # Linking against onemath_dft_portfft in CMake will add the required include directories and dependencies.
+  # This target should only be used for compile-time dispatching.
+  target_link_libraries(${EXAMPLE_TARGET} PUBLIC
+    onemath_dft_portfft
+  )
 
-# Include directories specific to the examples
-target_include_directories(${EXAMPLE_TARGET} PUBLIC
-  ${PROJECT_SOURCE_DIR}/examples/include
-)
+  # Include directories specific to the examples
+  target_include_directories(${EXAMPLE_TARGET} PUBLIC
+    ${PROJECT_SOURCE_DIR}/examples/include
+  )
 
-# Enable warnings
-include(WarningsUtils)
-target_link_libraries(${EXAMPLE_TARGET} PRIVATE onemath_warnings)
+  # Enable warnings
+  include(WarningsUtils)
+  target_link_libraries(${EXAMPLE_TARGET} PRIVATE onemath_warnings)
 
-# Register example as ctest
-add_test(NAME dft/EXAMPLE/CT/complex_fwd_usm_mklcpu_cufft COMMAND ${EXAMPLE_TARGET})
+  # Register example as ctest
+  add_test(NAME dft/EXAMPLE/CT/complex_fwd_usm_portfft COMMAND ${EXAMPLE_TARGET})
+endif()

--- a/examples/dft/compile_time_dispatching/complex_fwd_usm_portfft.cpp
+++ b/examples/dft/compile_time_dispatching/complex_fwd_usm_portfft.cpp
@@ -1,0 +1,154 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+/*
+*
+*  Content:
+*       This example demonstrates use of the DPCPP API
+*       oneapi::math::dft to perform a complex in-place forward transform
+*       using unified shared memory on a SYCL device (CPU, GPU) with the
+*       SYCL-only "portFFT" backend and compile-time dispatching.
+*
+*       Note that the portFFT backend only supports the COMPLEX domain.
+*
+*       This example demonstrates only single precision (float) data type.
+*
+*
+*******************************************************************************/
+
+// STL includes
+#include <iostream>
+#include <complex>
+
+// oneMath/SYCL includes
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+#include "oneapi/math.hpp"
+
+void run_example(const sycl::device& dev) {
+    constexpr std::size_t N = 16;
+
+    // Catch asynchronous exceptions
+    auto exception_handler = [](sycl::exception_list exceptions) {
+        for (std::exception_ptr const& e : exceptions) {
+            try {
+                std::rethrow_exception(e);
+            }
+            catch (sycl::exception const& e) {
+                std::cerr << "Caught asynchronous SYCL exception during execution:" << std::endl;
+                std::cerr << "\t" << e.what() << std::endl;
+            }
+        }
+        std::exit(2);
+    };
+
+    sycl::queue sycl_queue(dev, exception_handler);
+    auto in_out = sycl::malloc_shared<std::complex<float>>(N, sycl_queue);
+
+    // Initialize input data
+    for (std::size_t i = 0; i < N; ++i) {
+        in_out[i] = { static_cast<float>(i), static_cast<float>(-i) };
+    }
+
+    // 1. create descriptor
+    oneapi::math::dft::descriptor<oneapi::math::dft::precision::SINGLE,
+                                  oneapi::math::dft::domain::COMPLEX>
+        desc(static_cast<std::int64_t>(N));
+
+    // 2. variadic set_value
+    desc.set_value(oneapi::math::dft::config_param::PLACEMENT,
+                   oneapi::math::dft::config_value::INPLACE);
+    desc.set_value(oneapi::math::dft::config_param::NUMBER_OF_TRANSFORMS,
+                   static_cast<std::int64_t>(1));
+
+    // 3. commit_descriptor (compile-time portFFT)
+    desc.commit(oneapi::math::backend_selector<oneapi::math::backend::portfft>{ sycl_queue });
+
+    // 4. compute_forward (portFFT)
+    oneapi::math::dft::compute_forward<decltype(desc), std::complex<float>>(desc, in_out);
+
+    sycl_queue.wait_and_throw();
+
+    sycl::free(in_out, sycl_queue);
+}
+
+//
+// Description of example setup, apis used and supported floating point type precisions
+//
+void print_example_banner() {
+    std::cout << "\n"
+                 "########################################################################\n"
+                 "# Complex in-place forward transform for USM API's example:\n"
+                 "#\n"
+                 "# Using APIs:\n"
+                 "#   Compile-time dispatch API\n"
+                 "#   USM forward complex in-place\n"
+                 "#\n"
+                 "# Using single precision (float) data type\n"
+                 "#\n"
+                 "# Running on a SYCL device with the portFFT backend.\n"
+                 "#\n"
+                 "########################################################################\n"
+              << std::endl;
+}
+
+//
+// Main entry point for example.
+//
+int main(int /*argc*/, char** /*argv*/) {
+    print_example_banner();
+
+    try {
+        sycl::device dev((sycl::default_selector_v));
+
+        if (dev.is_gpu()) {
+            std::cout << "Running DFT complex forward example on GPU device" << std::endl;
+        }
+        else {
+            std::cout << "Running DFT complex forward example on CPU device" << std::endl;
+        }
+        std::cout << "Device name is: " << dev.get_info<sycl::info::device::name>() << std::endl;
+        std::cout << "Using compile-time dispatch API with portFFT." << std::endl;
+        std::cout << "Running with single precision real data type:" << std::endl;
+
+        run_example(dev);
+        std::cout << "DFT Complex USM example ran OK on portFFT" << std::endl;
+    }
+    catch (oneapi::math::unimplemented const& e) {
+        std::cerr << "Unsupported Configuration:" << std::endl;
+        std::cerr << "\t" << e.what() << std::endl;
+        return 0;
+    }
+    catch (sycl::exception const& e) {
+        std::cerr << "Caught synchronous SYCL exception:" << std::endl;
+        std::cerr << "\t" << e.what() << std::endl;
+        std::cerr << "\tSYCL error code: " << e.code().value() << std::endl;
+        return 1;
+    }
+    catch (std::exception const& e) {
+        std::cerr << "Caught std::exception:" << std::endl;
+        std::cerr << "\t" << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Closes #714.

The SYCL-only **generic BLAS** and **portFFT** backends cannot be combined with any other backend, so the existing compile-time dispatching examples (which pair `mklcpu` with a vendor GPU backend) do not cover them. This PR adds standalone, single-device compile-time dispatching examples so users can build and run something to validate these backends:

- `examples/blas/compile_time_dispatching/level3/gemm_usm_generic.cpp` — GEMM via `backend_selector<backend::generic>`, built when `ENABLE_GENERIC_BLAS_BACKEND` is on (links `onemath_blas_generic`).
- `examples/dft/compile_time_dispatching/complex_fwd_usm_portfft.cpp` — complex in-place forward DFT via `backend_selector<backend::portfft>`, built when `ENABLE_PORTFFT_BACKEND` is on (links `onemath_dft_portfft`). Only the COMPLEX domain is used since portFFT does not support REAL.

The BLAS and DFT compile-time `CMakeLists.txt` files are restructured to guard each backend combination independently (instead of an early `return()`), so the new SYCL-only examples build alongside the existing ones. Both examples are registered as ctests and documented in `examples/README.md` with sample output.

## Test plan

Built and run on an `Intel(R) Arc(TM) B580 Graphics` GPU with the DPC++ (icpx 2025.3.1) compiler:

```bash
cmake -B build -G Ninja \
  -DCMAKE_CXX_COMPILER=icpx -DCMAKE_C_COMPILER=icx \
  -DENABLE_MKLGPU_BACKEND=OFF -DENABLE_MKLCPU_BACKEND=OFF \
  -DENABLE_GENERIC_BLAS_BACKEND=ON -DENABLE_PORTFFT_BACKEND=ON \
  -DTARGET_DOMAINS="blas;dft" \
  -DBUILD_EXAMPLES=ON -DBUILD_SHARED_LIBS=ON \
  -DGENERIC_BLAS_TUNING_TARGET=INTEL_GPU
cmake --build build -j
```

Results:

- `example_blas_gemm_usm_generic` — ran OK, exit 0.
- `example_dft_complex_fwd_usm_portfft` — ran OK, exit 0.

Note for the reporter: the first run of each example is slow because the kernels are JIT-compiled by IGC on the B580; this can look like a hang. Allowing it to finish (or building AOT with `-fsycl-targets=spir64_gen -Xs "-device bmg"`) resolves it.