### PR TITLE
[blas] Make USM rotm param argument const

### DIFF
--- a/include/oneapi/math/blas.hxx
+++ b/include/oneapi/math/blas.hxx
@@ -3102,14 +3102,14 @@ static inline sycl::event rotg(sycl::queue& queue, std::complex<double>* a, std:
 }
 
 static inline sycl::event rotm(sycl::queue& queue, std::int64_t n, float* x, std::int64_t incx,
-                               float* y, std::int64_t incy, float* param,
+                               float* y, std::int64_t incy, const float* param,
                                const std::vector<sycl::event>& dependencies = {}) {
     auto done = detail::rotm(get_device_id(queue), queue, n, x, incx, y, incy, param, dependencies);
     return done;
 }
 
 static inline sycl::event rotm(sycl::queue& queue, std::int64_t n, double* x, std::int64_t incx,
-                               double* y, std::int64_t incy, double* param,
+                               double* y, std::int64_t incy, const double* param,
                                const std::vector<sycl::event>& dependencies = {}) {
     auto done = detail::rotm(get_device_id(queue), queue, n, x, incx, y, incy, param, dependencies);
     return done;

--- a/include/oneapi/math/blas/detail/armpl/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/armpl/blas_ct.hxx
@@ -3796,7 +3796,7 @@ sycl::event iamax(backend_selector<backend::armpl> selector, std::int64_t n,
 }
 
 sycl::event rotm(backend_selector<backend::armpl> selector, std::int64_t n, float* x,
-                 std::int64_t incx, float* y, std::int64_t incy, float* param,
+                 std::int64_t incx, float* y, std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);
@@ -3804,7 +3804,7 @@ sycl::event rotm(backend_selector<backend::armpl> selector, std::int64_t n, floa
 }
 
 sycl::event rotm(backend_selector<backend::armpl> selector, std::int64_t n, double* x,
-                 std::int64_t incx, double* y, std::int64_t incy, double* param,
+                 std::int64_t incx, double* y, std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);

--- a/include/oneapi/math/blas/detail/blas_ct_backends.hxx
+++ b/include/oneapi/math/blas/detail/blas_ct_backends.hxx
@@ -2592,11 +2592,13 @@ static inline sycl::event iamax(backend_selector<backend::BACKEND> selector, std
 
 static inline sycl::event rotm(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                float* x, std::int64_t incx, float* y, std::int64_t incy,
-                               float* param, const std::vector<sycl::event>& dependencies = {});
+                               const float* param,
+                               const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event rotm(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                double* x, std::int64_t incx, double* y, std::int64_t incy,
-                               double* param, const std::vector<sycl::event>& dependencies = {});
+                               const double* param,
+                               const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event rotg(backend_selector<backend::BACKEND> selector, float* a, float* b,
                                float* c, float* s,

--- a/include/oneapi/math/blas/detail/blas_loader.hxx
+++ b/include/oneapi/math/blas/detail/blas_loader.hxx
@@ -2331,10 +2331,12 @@ ONEMATH_EXPORT sycl::event spr2(oneapi::math::device libkey, sycl::queue& queue,
 
 ONEMATH_EXPORT sycl::event rotm(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                 float* x, std::int64_t incx, float* y, std::int64_t incy,
-                                float* param, const std::vector<sycl::event>& dependencies = {});
+                                const float* param,
+                                const std::vector<sycl::event>& dependencies = {});
 ONEMATH_EXPORT sycl::event rotm(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                 double* x, std::int64_t incx, double* y, std::int64_t incy,
-                                double* param, const std::vector<sycl::event>& dependencies = {});
+                                const double* param,
+                                const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event dot(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                const float* x, std::int64_t incx, const float* y, std::int64_t incy,

--- a/include/oneapi/math/blas/detail/cublas/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/cublas/blas_ct.hxx
@@ -3806,7 +3806,7 @@ sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n,
 }
 
 sycl::event rotm(backend_selector<backend::cublas> selector, std::int64_t n, float* x,
-                 std::int64_t incx, float* y, std::int64_t incy, float* param,
+                 std::int64_t incx, float* y, std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);
@@ -3814,7 +3814,7 @@ sycl::event rotm(backend_selector<backend::cublas> selector, std::int64_t n, flo
 }
 
 sycl::event rotm(backend_selector<backend::cublas> selector, std::int64_t n, double* x,
-                 std::int64_t incx, double* y, std::int64_t incy, double* param,
+                 std::int64_t incx, double* y, std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);

--- a/include/oneapi/math/blas/detail/cublas/onemath_blas_cublas.hxx
+++ b/include/oneapi/math/blas/detail/cublas/onemath_blas_cublas.hxx
@@ -1235,11 +1235,11 @@ sycl::event rotg(sycl::queue& queue, std::complex<double>* a, std::complex<doubl
                  std::complex<double>* s, const std::vector<sycl::event>& dependencies = {});
 
 sycl::event rotm(sycl::queue& queue, std::int64_t n, float* x, std::int64_t incx, float* y,
-                 std::int64_t incy, float* param,
+                 std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event rotm(sycl::queue& queue, std::int64_t n, double* x, std::int64_t incx, double* y,
-                 std::int64_t incy, double* param,
+                 std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event rotmg(sycl::queue& queue, float* d1, float* d2, float* x1, float y1, float* param,

--- a/include/oneapi/math/blas/detail/generic/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/generic/blas_ct.hxx
@@ -3814,7 +3814,7 @@ sycl::event iamax(backend_selector<backend::generic> selector, std::int64_t n,
 }
 
 sycl::event rotm(backend_selector<backend::generic> selector, std::int64_t n, float* x,
-                 std::int64_t incx, float* y, std::int64_t incy, float* param,
+                 std::int64_t incx, float* y, std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                          param, dependencies);
@@ -3822,7 +3822,7 @@ sycl::event rotm(backend_selector<backend::generic> selector, std::int64_t n, fl
 }
 
 sycl::event rotm(backend_selector<backend::generic> selector, std::int64_t n, double* x,
-                 std::int64_t incx, double* y, std::int64_t incy, double* param,
+                 std::int64_t incx, double* y, std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                          param, dependencies);

--- a/include/oneapi/math/blas/detail/mklcpu/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/mklcpu/blas_ct.hxx
@@ -3808,7 +3808,7 @@ sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n,
 }
 
 sycl::event rotm(backend_selector<backend::mklcpu> selector, std::int64_t n, float* x,
-                 std::int64_t incx, float* y, std::int64_t incy, float* param,
+                 std::int64_t incx, float* y, std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);
@@ -3816,7 +3816,7 @@ sycl::event rotm(backend_selector<backend::mklcpu> selector, std::int64_t n, flo
 }
 
 sycl::event rotm(backend_selector<backend::mklcpu> selector, std::int64_t n, double* x,
-                 std::int64_t incx, double* y, std::int64_t incy, double* param,
+                 std::int64_t incx, double* y, std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);

--- a/include/oneapi/math/blas/detail/mklgpu/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/mklgpu/blas_ct.hxx
@@ -3808,7 +3808,7 @@ sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n,
 }
 
 sycl::event rotm(backend_selector<backend::mklgpu> selector, std::int64_t n, float* x,
-                 std::int64_t incx, float* y, std::int64_t incy, float* param,
+                 std::int64_t incx, float* y, std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);
@@ -3816,7 +3816,7 @@ sycl::event rotm(backend_selector<backend::mklgpu> selector, std::int64_t n, flo
 }
 
 sycl::event rotm(backend_selector<backend::mklgpu> selector, std::int64_t n, double* x,
-                 std::int64_t incx, double* y, std::int64_t incy, double* param,
+                 std::int64_t incx, double* y, std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);

--- a/include/oneapi/math/blas/detail/netlib/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/netlib/blas_ct.hxx
@@ -3808,7 +3808,7 @@ sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n,
 }
 
 sycl::event rotm(backend_selector<backend::netlib> selector, std::int64_t n, float* x,
-                 std::int64_t incx, float* y, std::int64_t incy, float* param,
+                 std::int64_t incx, float* y, std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);
@@ -3816,7 +3816,7 @@ sycl::event rotm(backend_selector<backend::netlib> selector, std::int64_t n, flo
 }
 
 sycl::event rotm(backend_selector<backend::netlib> selector, std::int64_t n, double* x,
-                 std::int64_t incx, double* y, std::int64_t incy, double* param,
+                 std::int64_t incx, double* y, std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);

--- a/include/oneapi/math/blas/detail/onemath_blas_backends.hxx
+++ b/include/oneapi/math/blas/detail/onemath_blas_backends.hxx
@@ -2450,11 +2450,11 @@ ONEMATH_EXPORT sycl::event rotg(sycl::queue& queue, std::complex<double>* a,
                                 const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event rotm(sycl::queue& queue, std::int64_t n, float* x, std::int64_t incx,
-                                float* y, std::int64_t incy, float* param,
+                                float* y, std::int64_t incy, const float* param,
                                 const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event rotm(sycl::queue& queue, std::int64_t n, double* x, std::int64_t incx,
-                                double* y, std::int64_t incy, double* param,
+                                double* y, std::int64_t incy, const double* param,
                                 const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event rotmg(sycl::queue& queue, float* d1, float* d2, float* x1, float y1,

--- a/include/oneapi/math/blas/detail/openblas/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/openblas/blas_ct.hxx
@@ -3816,7 +3816,7 @@ sycl::event iamax(backend_selector<backend::openblas> selector, std::int64_t n,
 }
 
 sycl::event rotm(backend_selector<backend::openblas> selector, std::int64_t n, float* x,
-                 std::int64_t incx, float* y, std::int64_t incy, float* param,
+                 std::int64_t incx, float* y, std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::openblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                           param, dependencies);
@@ -3824,7 +3824,7 @@ sycl::event rotm(backend_selector<backend::openblas> selector, std::int64_t n, f
 }
 
 sycl::event rotm(backend_selector<backend::openblas> selector, std::int64_t n, double* x,
-                 std::int64_t incx, double* y, std::int64_t incy, double* param,
+                 std::int64_t incx, double* y, std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::openblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                           param, dependencies);

--- a/include/oneapi/math/blas/detail/rocblas/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/rocblas/blas_ct.hxx
@@ -3701,7 +3701,7 @@ sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n,
 }
 
 sycl::event rotm(backend_selector<backend::rocblas> selector, int64_t n, float* x, int64_t incx,
-                 float* y, int64_t incy, float* param,
+                 float* y, int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                          param, dependencies);
@@ -3709,7 +3709,7 @@ sycl::event rotm(backend_selector<backend::rocblas> selector, int64_t n, float* 
 }
 
 sycl::event rotm(backend_selector<backend::rocblas> selector, int64_t n, double* x, int64_t incx,
-                 double* y, int64_t incy, double* param,
+                 double* y, int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                          param, dependencies);

--- a/include/oneapi/math/blas/detail/rocblas/onemath_blas_rocblas.hxx
+++ b/include/oneapi/math/blas/detail/rocblas/onemath_blas_rocblas.hxx
@@ -1175,10 +1175,10 @@ sycl::event rotg(sycl::queue& queue, std::complex<double>* a, std::complex<doubl
                  std::complex<double>* s, const std::vector<sycl::event>& dependencies = {});
 
 sycl::event rotm(sycl::queue& queue, int64_t n, float* x, int64_t incx, float* y, int64_t incy,
-                 float* param, const std::vector<sycl::event>& dependencies = {});
+                 const float* param, const std::vector<sycl::event>& dependencies = {});
 
 sycl::event rotm(sycl::queue& queue, int64_t n, double* x, int64_t incx, double* y, int64_t incy,
-                 double* param, const std::vector<sycl::event>& dependencies = {});
+                 const double* param, const std::vector<sycl::event>& dependencies = {});
 
 sycl::event rotmg(sycl::queue& queue, float* d1, float* d2, float* x1, float y1, float* param,
                   const std::vector<sycl::event>& dependencies = {});

--- a/src/blas/backends/armpl/armpl_level1.cxx
+++ b/src/blas/backends/armpl/armpl_level1.cxx
@@ -698,8 +698,9 @@ ROTG_USM_LAUNCHER(std::complex<float>, float, ::cblas_crotg)
 ROTG_USM_LAUNCHER(std::complex<double>, double, ::cblas_zrotg)
 
 template <typename T, typename CBLAS_FUNC>
-sycl::event rotm(sycl::queue& queue, int64_t n, T* x, int64_t incx, T* y, int64_t incy, T* param,
-                 const std::vector<sycl::event>& dependencies, CBLAS_FUNC cblas_func) {
+sycl::event rotm(sycl::queue& queue, int64_t n, T* x, int64_t incx, T* y, int64_t incy,
+                 const T* param, const std::vector<sycl::event>& dependencies,
+                 CBLAS_FUNC cblas_func) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; ++i) {
@@ -712,7 +713,7 @@ sycl::event rotm(sycl::queue& queue, int64_t n, T* x, int64_t incx, T* y, int64_
 
 #define ROTM_USM_LAUNCHER(TYPE, ROUTINE)                                                          \
     sycl::event rotm(sycl::queue& queue, int64_t n, TYPE* x, int64_t incx, TYPE* y, int64_t incy, \
-                     TYPE* param, const std::vector<sycl::event>& dependencies) {                 \
+                     const TYPE* param, const std::vector<sycl::event>& dependencies) {           \
         return rotm(queue, n, x, incx, y, incy, param, dependencies, ROUTINE);                    \
     }
 

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -829,7 +829,7 @@ ROTG_LAUNCHER_USM(std::complex<double>, double, cublasZrotg)
 
 template <typename Func, typename T>
 inline sycl::event rotm(const char* func_name, Func func, sycl::queue& queue, int64_t n, T* x,
-                        int64_t incx, T* y, int64_t incy, T* param,
+                        int64_t incx, T* y, int64_t incy, const T* param,
                         const std::vector<sycl::event>& dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
@@ -842,7 +842,7 @@ inline sycl::event rotm(const char* func_name, Func func, sycl::queue& queue, in
             auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
-            auto param_ = reinterpret_cast<cuDataType*>(param);
+            auto param_ = reinterpret_cast<const cuDataType*>(param);
             cublasStatus_t err;
             cublas_native_named_func(func_name, func, err, handle, n, x_, incx, y_, incy, param_);
         });
@@ -852,7 +852,7 @@ inline sycl::event rotm(const char* func_name, Func func, sycl::queue& queue, in
 
 #define ROTM_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     sycl::event rotm(sycl::queue& queue, int64_t n, TYPE* x, int64_t incx, TYPE* y, int64_t incy, \
-                     TYPE* param, const std::vector<sycl::event>& dependencies) {                 \
+                     const TYPE* param, const std::vector<sycl::event>& dependencies) {           \
         return rotm(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, y, incy, param,           \
                     dependencies);                                                                \
     }
@@ -1696,14 +1696,14 @@ ROTG_LAUNCHER_USM(std::complex<double>, double, cublasZrotg)
 
 template <typename Func, typename T>
 inline sycl::event rotm(const char* func_name, Func func, sycl::queue& queue, int64_t n, T* x,
-                        int64_t incx, T* y, int64_t incy, T* param,
+                        int64_t incx, T* y, int64_t incy, const T* param,
                         const std::vector<sycl::event>& dependencies) {
     throw unimplemented("blas", "rotm", "for row_major layout");
 }
 
 #define ROTM_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     sycl::event rotm(sycl::queue& queue, int64_t n, TYPE* x, int64_t incx, TYPE* y, int64_t incy, \
-                     TYPE* param, const std::vector<sycl::event>& dependencies) {                 \
+                     const TYPE* param, const std::vector<sycl::event>& dependencies) {           \
         return rotm(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, y, incy, param,           \
                     dependencies);                                                                \
     }

--- a/src/blas/backends/generic/generic_level1.cxx
+++ b/src/blas/backends/generic/generic_level1.cxx
@@ -400,7 +400,8 @@ sycl::event rotg(sycl::queue& queue, std::complex<real_t>* a, std::complex<real_
 }
 
 sycl::event rotm(sycl::queue& queue, std::int64_t n, real_t* x, std::int64_t incx, real_t* y,
-                 std::int64_t incy, real_t* param, const std::vector<sycl::event>& dependencies) {
+                 std::int64_t incy, const real_t* param,
+                 const std::vector<sycl::event>& dependencies) {
     CALL_GENERIC_BLAS_USM_FN(::blas::_rotm, queue, n, x, incx, y, incy, param, dependencies);
 }
 

--- a/src/blas/backends/mkl_common/mkl_level1.cxx
+++ b/src/blas/backends/mkl_common/mkl_level1.cxx
@@ -820,13 +820,15 @@ sycl::event rotg(sycl::queue& queue, std::complex<double>* a, std::complex<doubl
 }
 
 sycl::event rotm(sycl::queue& queue, std::int64_t n, float* x, std::int64_t incx, float* y,
-                 std::int64_t incy, float* param, const std::vector<sycl::event>& dependencies) {
+                 std::int64_t incy, const float* param,
+                 const std::vector<sycl::event>& dependencies) {
     RETHROW_ONEMKL_EXCEPTIONS_RET(
         blas_major::rotm(queue, n, x, incx, y, incy, param, dependencies));
 }
 
 sycl::event rotm(sycl::queue& queue, std::int64_t n, double* x, std::int64_t incx, double* y,
-                 std::int64_t incy, double* param, const std::vector<sycl::event>& dependencies) {
+                 std::int64_t incy, const double* param,
+                 const std::vector<sycl::event>& dependencies) {
     RETHROW_ONEMKL_EXCEPTIONS_RET(
         blas_major::rotm(queue, n, x, incx, y, incy, param, dependencies));
 }

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -1361,7 +1361,7 @@ sycl::event rotg(sycl::queue& queue, std::complex<double>* a, std::complex<doubl
 }
 
 sycl::event rotm(sycl::queue& queue, int64_t n, float* x, int64_t incx, float* y, int64_t incy,
-                 float* param, const std::vector<sycl::event>& dependencies) {
+                 const float* param, const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1375,7 +1375,7 @@ sycl::event rotm(sycl::queue& queue, int64_t n, float* x, int64_t incx, float* y
 }
 
 sycl::event rotm(sycl::queue& queue, int64_t n, double* x, int64_t incx, double* y, int64_t incy,
-                 double* param, const std::vector<sycl::event>& dependencies) {
+                 const double* param, const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/openblas/openblas_level1.cxx
+++ b/src/blas/backends/openblas/openblas_level1.cxx
@@ -1443,7 +1443,7 @@ sycl::event rotg(sycl::queue& queue, std::complex<double>* a, std::complex<doubl
 }
 
 sycl::event rotm(sycl::queue& queue, int64_t n, float* x, int64_t incx, float* y, int64_t incy,
-                 float* param, const std::vector<sycl::event>& dependencies) {
+                 const float* param, const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1457,7 +1457,7 @@ sycl::event rotm(sycl::queue& queue, int64_t n, float* x, int64_t incx, float* y
 }
 
 sycl::event rotm(sycl::queue& queue, int64_t n, double* x, int64_t incx, double* y, int64_t incy,
-                 double* param, const std::vector<sycl::event>& dependencies) {
+                 const double* param, const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/rocblas/rocblas_level1.cpp
+++ b/src/blas/backends/rocblas/rocblas_level1.cpp
@@ -840,7 +840,8 @@ ROTG_LAUNCHER_USM(std::complex<double>, double, rocblas_zrotg)
 
 template <typename Func, typename T>
 inline sycl::event rotm(Func func, sycl::queue& queue, int64_t n, T* x, int64_t incx, T* y,
-                        int64_t incy, T* param, const std::vector<sycl::event>& dependencies) {
+                        int64_t incy, const T* param,
+                        const std::vector<sycl::event>& dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
 
@@ -851,7 +852,7 @@ inline sycl::event rotm(Func func, sycl::queue& queue, int64_t n, T* x, int64_t 
 
             auto x_ = reinterpret_cast<rocDataType*>(x);
             auto y_ = reinterpret_cast<rocDataType*>(y);
-            auto param_ = reinterpret_cast<rocDataType*>(param);
+            auto param_ = reinterpret_cast<const rocDataType*>(param);
             rocblas_status err;
             rocblas_native_func(func, err, handle, n, x_, incx, y_, incy, param_);
         });
@@ -862,7 +863,7 @@ inline sycl::event rotm(Func func, sycl::queue& queue, int64_t n, T* x, int64_t 
 
 #define ROTM_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
     sycl::event rotm(sycl::queue& queue, int64_t n, TYPE* x, int64_t incx, TYPE* y, int64_t incy, \
-                     TYPE* param, const std::vector<sycl::event>& dependencies) {                 \
+                     const TYPE* param, const std::vector<sycl::event>& dependencies) {           \
         return rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);            \
     }
 
@@ -1608,13 +1609,14 @@ ROTG_LAUNCHER_USM(std::complex<double>, double, rocblas_zrotg)
 
 template <typename Func, typename T>
 inline sycl::event rotm(Func func, sycl::queue& queue, int64_t n, T* x, int64_t incx, T* y,
-                        int64_t incy, T* param, const std::vector<sycl::event>& dependencies) {
+                        int64_t incy, const T* param,
+                        const std::vector<sycl::event>& dependencies) {
     return column_major::rotm(func, queue, n, x, incx, y, incy, param, dependencies);
 }
 
 #define ROTM_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
     sycl::event rotm(sycl::queue& queue, int64_t n, TYPE* x, int64_t incx, TYPE* y, int64_t incy, \
-                     TYPE* param, const std::vector<sycl::event>& dependencies) {                 \
+                     const TYPE* param, const std::vector<sycl::event>& dependencies) {           \
         return rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);            \
     }
 

--- a/src/blas/blas_loader.cpp
+++ b/src/blas/blas_loader.cpp
@@ -2183,14 +2183,14 @@ sycl::event rotg(oneapi::math::device libkey, sycl::queue& queue, std::complex<d
 }
 
 sycl::event rotm(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, float* x,
-                 std::int64_t incx, float* y, std::int64_t incy, float* param,
+                 std::int64_t incx, float* y, std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].column_major_srotm_usm_sycl(
         queue, n, x, incx, y, incy, param, dependencies);
 }
 
 sycl::event rotm(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, double* x,
-                 std::int64_t incx, double* y, std::int64_t incy, double* param,
+                 std::int64_t incx, double* y, std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].column_major_drotm_usm_sycl(
         queue, n, x, incx, y, incy, param, dependencies);
@@ -6165,14 +6165,14 @@ sycl::event rotg(oneapi::math::device libkey, sycl::queue& queue, std::complex<d
 }
 
 sycl::event rotm(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, float* x,
-                 std::int64_t incx, float* y, std::int64_t incy, float* param,
+                 std::int64_t incx, float* y, std::int64_t incy, const float* param,
                  const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_srotm_usm_sycl(queue, n, x, incx, y, incy,
                                                                        param, dependencies);
 }
 
 sycl::event rotm(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, double* x,
-                 std::int64_t incx, double* y, std::int64_t incy, double* param,
+                 std::int64_t incx, double* y, std::int64_t incy, const double* param,
                  const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_drotm_usm_sycl(queue, n, x, incx, y, incy,
                                                                        param, dependencies);

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -1365,11 +1365,11 @@ typedef struct {
                                                const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_srotm_usm_sycl)(sycl::queue& queue, std::int64_t n, float* x,
                                                std::int64_t incx, float* y, std::int64_t incy,
-                                               float* param,
+                                               const float* param,
                                                const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_drotm_usm_sycl)(sycl::queue& queue, std::int64_t n, double* x,
                                                std::int64_t incx, double* y, std::int64_t incy,
-                                               double* param,
+                                               const double* param,
                                                const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_srotmg_usm_sycl)(sycl::queue& queue, float* d1, float* d2, float* x1,
                                                 float y1, float* param,
@@ -3833,11 +3833,11 @@ typedef struct {
                                             const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_srotm_usm_sycl)(sycl::queue& queue, std::int64_t n, float* x,
                                             std::int64_t incx, float* y, std::int64_t incy,
-                                            float* param,
+                                            const float* param,
                                             const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_drotm_usm_sycl)(sycl::queue& queue, std::int64_t n, double* x,
                                             std::int64_t incx, double* y, std::int64_t incy,
-                                            double* param,
+                                            const double* param,
                                             const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_srotmg_usm_sycl)(sycl::queue& queue, float* d1, float* d2, float* x1,
                                              float y1, float* param,

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -86,16 +86,23 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx, int incy, fp
 
     // Call DPC++ ROTM.
 
+    // param is a read-only input, so it is passed through a const pointer. This
+    // ensures the const-correct USM rotm API (uxlfoundation/oneMath#592) is
+    // exercised: a mutable pointer would also compile against the old
+    // non-const signature, whereas a const pointer enforces the fixed
+    // signature at compile time for both the RT and CT dispatch paths.
+    const fp* param_ptr = param.data();
+
     try {
 #ifdef CALL_RT_API
         switch (layout) {
             case oneapi::math::layout::col_major:
                 done = oneapi::math::blas::column_major::rotm(
-                    main_queue, N, x.data(), incx, y.data(), incy, param.data(), dependencies);
+                    main_queue, N, x.data(), incx, y.data(), incy, param_ptr, dependencies);
                 break;
             case oneapi::math::layout::row_major:
                 done = oneapi::math::blas::row_major::rotm(main_queue, N, x.data(), incx, y.data(),
-                                                           incy, param.data(), dependencies);
+                                                           incy, param_ptr, dependencies);
                 break;
             default: break;
         }
@@ -104,11 +111,11 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx, int incy, fp
         switch (layout) {
             case oneapi::math::layout::col_major:
                 TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::math::blas::column_major::rotm, N,
-                                        x.data(), incx, y.data(), incy, param.data(), dependencies);
+                                        x.data(), incx, y.data(), incy, param_ptr, dependencies);
                 break;
             case oneapi::math::layout::row_major:
                 TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::math::blas::row_major::rotm, N,
-                                        x.data(), incx, y.data(), incy, param.data(), dependencies);
+                                        x.data(), incx, y.data(), incy, param_ptr, dependencies);
                 break;
             default: break;
         }


### PR DESCRIPTION
## Summary

The oneAPI specification declares the 7th argument (`param`) of the USM version of `rotm` as `const T *` (see the [rotm spec](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/domains/blas/rotm#rotm-usm-version)), but the oneMath headers and backends declared it as `T *`. `param` is a read-only input containing the `flag` and the components of the modified Givens rotation matrix `H`, so it should be `const`.

This PR makes the USM `rotm` interface const-correct and consistent with the specification (the in-tree spec `docs/spec/domains/blas/rotm.rst` already uses `const T *param`). The buffer version was already correct (it uses a read accessor) and is unchanged.

Fixes #592.

## Changes

Updated the `const`-ness of `param` in the USM `rotm` overloads across every layer so the signatures stay consistent:

- Public API: `include/oneapi/math/blas.hxx`
- Backend dispatch / loader / CT headers: `onemath_blas_backends.hxx`, `blas_loader.hxx`, `blas_ct_backends.hxx`, and every backend `blas_ct.hxx`
- Backend declaration headers: `onemath_blas_cublas.hxx`, `onemath_blas_rocblas.hxx`
- Loader + function table: `src/blas/blas_loader.cpp`, `src/blas/function_table.hpp`
- Backends: `mkl_common`, `cublas`, `rocblas`, `netlib`, `openblas`, `generic`, `armpl`

The cuBLAS/rocBLAS wrappers now `reinterpret_cast` `param` to a `const` device-type pointer (the underlying `cublas*rotm`/`rocblas_*rotm` already take `const` param).

## Test plan

- [x] `clang-format` (pre-commit v19.1.0) passes.
- [x] Built the **MKL GPU** backend (BLAS) and ran the functional tests on an Intel Arc A770; `RotmTests` and `RotmUsmTests` (CT + RT, column- and row-major, single precision) **pass**. Double precision skipped (device lacks fp64).
- [x] **cuBLAS** backend library compiles cleanly against CUDA 12.1 with the const change.
- [x] **rocBLAS** backend object compiles cleanly against ROCm 6.4.4 with the const change.
