### PR TITLE
[lapack] Report unimplemented for cusolver gesvd when m < n

### DIFF
--- a/src/lapack/backends/cusolver/cusolver_lapack.cpp
+++ b/src/lapack/backends/cusolver/cusolver_lapack.cpp
@@ -274,6 +274,11 @@ inline void gesvd(const char* func_name, Func func, sycl::queue& queue, oneapi::
     using cuDataType_A = typename CudaEquivalentType<T_A>::Type;
     using cuDataType_B = typename CudaEquivalentType<T_B>::Type;
     overflow_check(n, m, lda, ldu, ldvt, scratchpad_size);
+
+    // cusolver gesvd only supports m >= n (see cuSOLVER documentation).
+    if (m < n)
+        throw unimplemented("lapack", "gesvd", "cusolver gesvd does not support m < n");
+
     sycl::buffer<int> devInfo{ 1 };
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
@@ -1459,6 +1464,11 @@ inline sycl::event gesvd(const char* func_name, Func func, sycl::queue& queue,
     using cuDataType_A = typename CudaEquivalentType<T_A>::Type;
     using cuDataType_B = typename CudaEquivalentType<T_B>::Type;
     overflow_check(m, n, lda, ldu, ldvt, scratchpad_size);
+
+    // cusolver gesvd only supports m >= n (see cuSOLVER documentation).
+    if (m < n)
+        throw unimplemented("lapack", "gesvd", "cusolver gesvd does not support m < n");
+
     int* devInfo = (int*)malloc_device(sizeof(int), queue);
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
@@ -2538,6 +2548,10 @@ inline void gesvd_scratchpad_size(const char* func_name, Func func, sycl::queue&
                                   oneapi::math::jobsvd jobu, oneapi::math::jobsvd jobvt,
                                   std::int64_t m, std::int64_t n, std::int64_t lda,
                                   std::int64_t ldu, std::int64_t ldvt, int* scratch_size) {
+    // cusolver gesvd only supports m >= n (see cuSOLVER documentation).
+    if (m < n)
+        throw unimplemented("lapack", "gesvd", "cusolver gesvd does not support m < n");
+
     queue
         .submit([&](sycl::handler& cgh) {
             onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {

--- a/tests/unit_tests/lapack/source/gesvd.cpp
+++ b/tests/unit_tests/lapack/source/gesvd.cpp
@@ -38,6 +38,7 @@ namespace {
 const char* accuracy_input = R"(
 1 1 8 8 10 10 10 27182
 1 1 30 24 42 33 33 27182
+1 1 24 30 33 33 42 27182
 )";
 
 template <typename data_T>


### PR DESCRIPTION
## Description

cuSOLVER's `gesvd` only supports `m >= n` (see the [cuSOLVER documentation](https://docs.nvidia.com/cuda/cusolver/index.html#cuSolverDN-lt-t-gt-gesvd), "Remark 1: gesvd only supports m>=n"). Previously the cusolver backend silently returned an empty/invalid result when `m < n`, as reported in #561.

This PR throws `oneapi::math::unimplemented` for `m < n` in the buffer, USM, and `gesvd_scratchpad_size` paths of the cusolver backend, so the limitation is reported to the user. This mirrors the existing `gebrd` behavior in the same backend.

rocSOLVER's `gesvd` supports `m < n`, so no change is needed there.

## Testing

Added an `m < n` accuracy test case to `tests/unit_tests/lapack/source/gesvd.cpp`. The test harness treats `unimplemented` as *skipped*, so this case validates the rocSOLVER and reference (MKL) backends while being cleanly skipped on cusolver.

Fixes #561