### PR TITLE
[cublas] Implement dgmm_batch backend

### DIFF
--- a/src/blas/backends/cublas/cublas_batch.cpp
+++ b/src/blas/backends/cublas/cublas_batch.cpp
@@ -110,35 +110,50 @@ void gemv_batch(sycl::queue& queue, transpose transa, int64_t m, int64_t n,
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                sycl::buffer<float, 1>& a, int64_t lda, int64_t stride_a, sycl::buffer<float, 1>& x,
-                int64_t incx, int64_t stride_x, sycl::buffer<float, 1>& c, int64_t ldc,
-                int64_t stride_c, int64_t batch_size) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
+// cuBLAS has no batched/strided variant of <t>dgmm (only cublas<t>dgmm), so
+// dgmm_batch is implemented as a loop of cublas<t>dgmm calls. See issue #562.
+template <typename Func, typename T>
+inline void dgmm_batch(const char* func_name, Func func, sycl::queue& queue, side left_right,
+                       int64_t m, int64_t n, sycl::buffer<T, 1>& a, int64_t lda, int64_t stride_a,
+                       sycl::buffer<T, 1>& x, int64_t incx, int64_t stride_x, sycl::buffer<T, 1>& c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, lda, ldc, stride_a, stride_x, stride_c, batch_size);
+    queue.submit([&](sycl::handler& cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
+            auto a_ = sc.get_mem<cuDataType*>(a_acc);
+            auto x_ = sc.get_mem<cuDataType*>(x_acc);
+            auto c_ = sc.get_mem<cuDataType*>(c_acc);
+            cublasStatus_t err;
+            auto mode = get_cublas_side_mode(left_right);
+            for (int64_t i = 0; i < batch_size; i++) {
+                cublas_native_named_func(func_name, func, err, handle, mode, (int)m, (int)n,
+                                         a_ + i * stride_a, (int)lda, x_ + i * stride_x, (int)incx,
+                                         c_ + i * stride_c, (int)ldc);
+            }
+        });
+    });
 }
 
-void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                sycl::buffer<double, 1>& a, int64_t lda, int64_t stride_a,
-                sycl::buffer<double, 1>& x, int64_t incx, int64_t stride_x,
-                sycl::buffer<double, 1>& c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
-}
+#define DGMM_STRIDED_BATCH_LAUNCHER(TYPE, CUBLAS_ROUTINE)                                          \
+    void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,                     \
+                    sycl::buffer<TYPE, 1>& a, int64_t lda, int64_t stride_a,                       \
+                    sycl::buffer<TYPE, 1>& x, int64_t incx, int64_t stride_x,                      \
+                    sycl::buffer<TYPE, 1>& c, int64_t ldc, int64_t stride_c, int64_t batch_size) { \
+        dgmm_batch(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, left_right, m, n, a, lda, stride_a, x,  \
+                   incx, stride_x, c, ldc, stride_c, batch_size);                                  \
+    }
 
-void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                sycl::buffer<std::complex<float>, 1>& a, int64_t lda, int64_t stride_a,
-                sycl::buffer<std::complex<float>, 1>& x, int64_t incx, int64_t stride_x,
-                sycl::buffer<std::complex<float>, 1>& c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
-}
+DGMM_STRIDED_BATCH_LAUNCHER(float, cublasSdgmm)
+DGMM_STRIDED_BATCH_LAUNCHER(double, cublasDdgmm)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<float>, cublasCdgmm)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<double>, cublasZdgmm)
 
-void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                sycl::buffer<std::complex<double>, 1>& a, int64_t lda, int64_t stride_a,
-                sycl::buffer<std::complex<double>, 1>& x, int64_t incx, int64_t stride_x,
-                sycl::buffer<std::complex<double>, 1>& c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
-}
+#undef DGMM_STRIDED_BATCH_LAUNCHER
 
 template <typename Ta, typename Tb, typename Tc, typename Ts>
 inline void gemm_batch_impl(sycl::queue& queue, transpose transa, transpose transb, int64_t m,
@@ -550,63 +565,103 @@ GEMV_BATCH_LAUNCHER_USM(std::complex<double>, cublasZgemvBatched)
 
 #undef GEMV_BATCH_LAUNCHER_USM
 
-sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n, const float* a,
-                       int64_t lda, int64_t stride_a, const float* x, int64_t incx,
-                       int64_t stride_x, float* c, int64_t ldc, int64_t stride_c,
-                       int64_t batch_size, const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
+// USM strided dgmm_batch: loop over cublas<t>dgmm (no native batched variant).
+template <typename Func, typename T>
+inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& queue, side left_right,
+                              int64_t m, int64_t n, const T* a, int64_t lda, int64_t stride_a,
+                              const T* x, int64_t incx, int64_t stride_x, T* c, int64_t ldc,
+                              int64_t stride_c, int64_t batch_size,
+                              const std::vector<sycl::event>& dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    overflow_check(m, n, lda, ldc, stride_a, stride_x, stride_c, batch_size);
+    auto done = queue.submit([&](sycl::handler& cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
+            auto a_ = reinterpret_cast<const cuDataType*>(a);
+            auto x_ = reinterpret_cast<const cuDataType*>(x);
+            auto c_ = reinterpret_cast<cuDataType*>(c);
+            cublasStatus_t err;
+            auto mode = get_cublas_side_mode(left_right);
+            for (int64_t i = 0; i < batch_size; i++) {
+                cublas_native_named_func(func_name, func, err, handle, mode, (int)m, (int)n,
+                                         a_ + i * stride_a, (int)lda, x_ + i * stride_x, (int)incx,
+                                         c_ + i * stride_c, (int)ldc);
+            }
+        });
+    });
+    return done;
 }
 
-sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n, const double* a,
-                       int64_t lda, int64_t stride_a, const double* x, int64_t incx,
-                       int64_t stride_x, double* c, int64_t ldc, int64_t stride_c,
-                       int64_t batch_size, const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
+#define DGMM_STRIDED_BATCH_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                       \
+    sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,               \
+                           const TYPE* a, int64_t lda, int64_t stride_a, const TYPE* x,             \
+                           int64_t incx, int64_t stride_x, TYPE* c, int64_t ldc, int64_t stride_c,  \
+                           int64_t batch_size, const std::vector<sycl::event>& dependencies) {      \
+        return dgmm_batch(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, left_right, m, n, a, lda,         \
+                          stride_a, x, incx, stride_x, c, ldc, stride_c, batch_size, dependencies); \
+    }
+
+DGMM_STRIDED_BATCH_LAUNCHER_USM(float, cublasSdgmm)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(double, cublasDdgmm)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>, cublasCdgmm)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, cublasZdgmm)
+
+#undef DGMM_STRIDED_BATCH_LAUNCHER_USM
+
+// USM group dgmm_batch: loop over groups and group members calling cublas<t>dgmm.
+template <typename Func, typename T>
+inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& queue, side* left_right,
+                              int64_t* m, int64_t* n, const T** a, int64_t* lda, const T** x,
+                              int64_t* incx, T** c, int64_t* ldc, int64_t group_count,
+                              int64_t* groupsize, const std::vector<sycl::event>& dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    for (int64_t i = 0; i < group_count; i++) {
+        overflow_check(m[i], n[i], lda[i], ldc[i], groupsize[i]);
+    }
+    auto done = queue.submit([&](sycl::handler& cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
+            cublasStatus_t err;
+            int64_t offset = 0;
+            for (int64_t i = 0; i < group_count; i++) {
+                auto mode = get_cublas_side_mode(left_right[i]);
+                for (int64_t j = 0; j < groupsize[i]; j++) {
+                    auto a_ = reinterpret_cast<const cuDataType*>(a[offset + j]);
+                    auto x_ = reinterpret_cast<const cuDataType*>(x[offset + j]);
+                    auto c_ = reinterpret_cast<cuDataType*>(c[offset + j]);
+                    cublas_native_named_func(func_name, func, err, handle, mode, (int)m[i], (int)n[i],
+                                             a_, (int)lda[i], x_, (int)incx[i], c_, (int)ldc[i]);
+                }
+                offset += groupsize[i];
+            }
+        });
+    });
+    return done;
 }
 
-sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                       const std::complex<float>* a, int64_t lda, int64_t stride_a,
-                       const std::complex<float>* x, int64_t incx, int64_t stride_x,
-                       std::complex<float>* c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                       const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
-}
+#define DGMM_GROUP_BATCH_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                       \
+    sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,          \
+                           const TYPE** a, int64_t* lda, const TYPE** x, int64_t* incx, TYPE** c, \
+                           int64_t* ldc, int64_t group_count, int64_t* groupsize,                 \
+                           const std::vector<sycl::event>& dependencies) {                        \
+        return dgmm_batch(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, left_right, m, n, a, lda, x,    \
+                          incx, c, ldc, group_count, groupsize, dependencies);                    \
+    }
 
-sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                       const std::complex<double>* a, int64_t lda, int64_t stride_a,
-                       const std::complex<double>* x, int64_t incx, int64_t stride_x,
-                       std::complex<double>* c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                       const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
-}
+DGMM_GROUP_BATCH_LAUNCHER_USM(float, cublasSdgmm)
+DGMM_GROUP_BATCH_LAUNCHER_USM(double, cublasDdgmm)
+DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<float>, cublasCdgmm)
+DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<double>, cublasZdgmm)
 
-sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,
-                       const float** a, int64_t* lda, const float** x, int64_t* incx, float** c,
-                       int64_t* ldc, int64_t group_count, int64_t* groupsize,
-                       const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
-}
-
-sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,
-                       const double** a, int64_t* lda, const double** x, int64_t* incx, double** c,
-                       int64_t* ldc, int64_t group_count, int64_t* groupsize,
-                       const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
-}
-
-sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,
-                       const std::complex<float>** a, int64_t* lda, const std::complex<float>** x,
-                       int64_t* incx, std::complex<float>** c, int64_t* ldc, int64_t group_count,
-                       int64_t* groupsize, const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
-}
-
-sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,
-                       const std::complex<double>** a, int64_t* lda, const std::complex<double>** x,
-                       int64_t* incx, std::complex<double>** c, int64_t* ldc, int64_t group_count,
-                       int64_t* groupsize, const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for column_major layout");
-}
+#undef DGMM_GROUP_BATCH_LAUNCHER_USM
 
 template <typename Ta, typename Tb, typename Tc, typename Ts>
 inline sycl::event gemm_batch_strided_usm_impl(sycl::queue& queue, transpose transa,
@@ -1162,35 +1217,27 @@ void gemv_batch(sycl::queue& queue, transpose transa, int64_t m, int64_t n,
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                sycl::buffer<float, 1>& a, int64_t lda, int64_t stride_a, sycl::buffer<float, 1>& x,
-                int64_t incx, int64_t stride_x, sycl::buffer<float, 1>& c, int64_t ldc,
-                int64_t stride_c, int64_t batch_size) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
+// Row-major dgmm_batch maps to column-major by swapping the side and m/n.
+static inline side dgmm_flip_side(side left_right) {
+    return left_right == oneapi::math::side::left ? oneapi::math::side::right
+                                                  : oneapi::math::side::left;
 }
 
-void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                sycl::buffer<double, 1>& a, int64_t lda, int64_t stride_a,
-                sycl::buffer<double, 1>& x, int64_t incx, int64_t stride_x,
-                sycl::buffer<double, 1>& c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
+#define DGMM_STRIDED_BATCH_LAUNCHER(TYPE)                                                          \
+    void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,                     \
+                    sycl::buffer<TYPE, 1>& a, int64_t lda, int64_t stride_a,                       \
+                    sycl::buffer<TYPE, 1>& x, int64_t incx, int64_t stride_x,                      \
+                    sycl::buffer<TYPE, 1>& c, int64_t ldc, int64_t stride_c, int64_t batch_size) { \
+        column_major::dgmm_batch(queue, dgmm_flip_side(left_right), n, m, a, lda, stride_a, x,      \
+                                 incx, stride_x, c, ldc, stride_c, batch_size);                     \
+    }
 
-void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                sycl::buffer<std::complex<float>, 1>& a, int64_t lda, int64_t stride_a,
-                sycl::buffer<std::complex<float>, 1>& x, int64_t incx, int64_t stride_x,
-                sycl::buffer<std::complex<float>, 1>& c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
+DGMM_STRIDED_BATCH_LAUNCHER(float)
+DGMM_STRIDED_BATCH_LAUNCHER(double)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<float>)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<double>)
 
-void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                sycl::buffer<std::complex<double>, 1>& a, int64_t lda, int64_t stride_a,
-                sycl::buffer<std::complex<double>, 1>& x, int64_t incx, int64_t stride_x,
-                sycl::buffer<std::complex<double>, 1>& c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
+#undef DGMM_STRIDED_BATCH_LAUNCHER
 
 #define GEMM_STRIDED_BATCH_LAUNCHER(TYPE_A, TYPE_B, TYPE_C, TYPE_S)                               \
     void gemm_batch(sycl::queue& queue, transpose transa, transpose transb, int64_t m, int64_t n, \
@@ -1521,63 +1568,40 @@ sycl::event gemv_batch(sycl::queue& queue, transpose* transa, int64_t* m, int64_
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n, const float* a,
-                       int64_t lda, int64_t stride_a, const float* x, int64_t incx,
-                       int64_t stride_x, float* c, int64_t ldc, int64_t stride_c,
-                       int64_t batch_size, const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
+#define DGMM_STRIDED_BATCH_LAUNCHER_USM(TYPE)                                                       \
+    sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,               \
+                           const TYPE* a, int64_t lda, int64_t stride_a, const TYPE* x,             \
+                           int64_t incx, int64_t stride_x, TYPE* c, int64_t ldc, int64_t stride_c,  \
+                           int64_t batch_size, const std::vector<sycl::event>& dependencies) {      \
+        return column_major::dgmm_batch(queue, dgmm_flip_side(left_right), n, m, a, lda, stride_a,  \
+                                        x, incx, stride_x, c, ldc, stride_c, batch_size,            \
+                                        dependencies);                                              \
+    }
 
-sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n, const double* a,
-                       int64_t lda, int64_t stride_a, const double* x, int64_t incx,
-                       int64_t stride_x, double* c, int64_t ldc, int64_t stride_c,
-                       int64_t batch_size, const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
+DGMM_STRIDED_BATCH_LAUNCHER_USM(float)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(double)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>)
 
-sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                       const std::complex<float>* a, int64_t lda, int64_t stride_a,
-                       const std::complex<float>* x, int64_t incx, int64_t stride_x,
-                       std::complex<float>* c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                       const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
+#undef DGMM_STRIDED_BATCH_LAUNCHER_USM
 
-sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,
-                       const std::complex<double>* a, int64_t lda, int64_t stride_a,
-                       const std::complex<double>* x, int64_t incx, int64_t stride_x,
-                       std::complex<double>* c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                       const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
+#define DGMM_GROUP_BATCH_LAUNCHER_USM(TYPE)                                                      \
+    sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,          \
+                           const TYPE** a, int64_t* lda, const TYPE** x, int64_t* incx, TYPE** c, \
+                           int64_t* ldc, int64_t group_count, int64_t* groupsize,                 \
+                           const std::vector<sycl::event>& dependencies) {                        \
+        for (int64_t i = 0; i < group_count; i++)                                                 \
+            left_right[i] = dgmm_flip_side(left_right[i]);                                         \
+        return column_major::dgmm_batch(queue, left_right, n, m, a, lda, x, incx, c, ldc,         \
+                                        group_count, groupsize, dependencies);                    \
+    }
 
-sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,
-                       const float** a, int64_t* lda, const float** x, int64_t* incx, float** c,
-                       int64_t* ldc, int64_t group_count, int64_t* groupsize,
-                       const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
+DGMM_GROUP_BATCH_LAUNCHER_USM(float)
+DGMM_GROUP_BATCH_LAUNCHER_USM(double)
+DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<float>)
+DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<double>)
 
-sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,
-                       const double** a, int64_t* lda, const double** x, int64_t* incx, double** c,
-                       int64_t* ldc, int64_t group_count, int64_t* groupsize,
-                       const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
-
-sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,
-                       const std::complex<float>** a, int64_t* lda, const std::complex<float>** x,
-                       int64_t* incx, std::complex<float>** c, int64_t* ldc, int64_t group_count,
-                       int64_t* groupsize, const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
-
-sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,
-                       const std::complex<double>** a, int64_t* lda, const std::complex<double>** x,
-                       int64_t* incx, std::complex<double>** c, int64_t* ldc, int64_t group_count,
-                       int64_t* groupsize, const std::vector<sycl::event>& dependencies) {
-    throw unimplemented("blas", "dgmm_batch", "for row_major layout");
-}
+#undef DGMM_GROUP_BATCH_LAUNCHER_USM
 
 #define GEMM_STRIDED_BATCH_LAUNCHER_USM(TYPE_A, TYPE_B, TYPE_C, TYPE_S)                        \
     sycl::event gemm_batch(sycl::queue& queue, transpose transa, transpose transb, int64_t m,  \

--- a/src/blas/backends/cublas/cublas_batch.cpp
+++ b/src/blas/backends/cublas/cublas_batch.cpp
@@ -25,6 +25,13 @@ namespace oneapi {
 namespace math {
 namespace blas {
 namespace cublas {
+
+// Row-major dgmm_batch maps to column-major by swapping the side and m/n.
+static inline side dgmm_flip_side(side left_right) {
+    return left_right == oneapi::math::side::left ? oneapi::math::side::right
+                                                  : oneapi::math::side::left;
+}
+
 namespace column_major {
 
 // Buffer APIs
@@ -594,13 +601,14 @@ inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& que
     return done;
 }
 
-#define DGMM_STRIDED_BATCH_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                       \
-    sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,               \
-                           const TYPE* a, int64_t lda, int64_t stride_a, const TYPE* x,             \
-                           int64_t incx, int64_t stride_x, TYPE* c, int64_t ldc, int64_t stride_c,  \
-                           int64_t batch_size, const std::vector<sycl::event>& dependencies) {      \
-        return dgmm_batch(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, left_right, m, n, a, lda,         \
-                          stride_a, x, incx, stride_x, c, ldc, stride_c, batch_size, dependencies); \
+#define DGMM_STRIDED_BATCH_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                      \
+    sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,              \
+                           const TYPE* a, int64_t lda, int64_t stride_a, const TYPE* x,            \
+                           int64_t incx, int64_t stride_x, TYPE* c, int64_t ldc, int64_t stride_c, \
+                           int64_t batch_size, const std::vector<sycl::event>& dependencies) {     \
+        return dgmm_batch(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, left_right, m, n, a, lda,        \
+                          stride_a, x, incx, stride_x, c, ldc, stride_c, batch_size,               \
+                          dependencies);                                                           \
     }
 
 DGMM_STRIDED_BATCH_LAUNCHER_USM(float, cublasSdgmm_64)
@@ -611,11 +619,14 @@ DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, cublasZdgmm_64)
 #undef DGMM_STRIDED_BATCH_LAUNCHER_USM
 
 // USM group dgmm_batch: loop over groups and group members calling cublas<t>dgmm.
+// flip_side lets the row-major layer reverse each group's side without writing to
+// the caller's left_right array, which the spec defines as an input parameter.
 template <typename Func, typename T>
-inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& queue, side* left_right,
-                              int64_t* m, int64_t* n, const T** a, int64_t* lda, const T** x,
-                              int64_t* incx, T** c, int64_t* ldc, int64_t group_count,
-                              int64_t* groupsize, const std::vector<sycl::event>& dependencies) {
+inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& queue,
+                              side* left_right, int64_t* m, int64_t* n, const T** a, int64_t* lda,
+                              const T** x, int64_t* incx, T** c, int64_t* ldc, int64_t group_count,
+                              int64_t* groupsize, const std::vector<sycl::event>& dependencies,
+                              bool flip_side = false) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
@@ -627,7 +638,8 @@ inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& que
             cublasStatus_t err;
             int64_t offset = 0;
             for (int64_t i = 0; i < group_count; i++) {
-                auto mode = get_cublas_side_mode(left_right[i]);
+                auto mode =
+                    get_cublas_side_mode(flip_side ? dgmm_flip_side(left_right[i]) : left_right[i]);
                 for (int64_t j = 0; j < groupsize[i]; j++) {
                     auto a_ = reinterpret_cast<const cuDataType*>(a[offset + j]);
                     auto x_ = reinterpret_cast<const cuDataType*>(x[offset + j]);
@@ -1212,19 +1224,13 @@ void gemv_batch(sycl::queue& queue, transpose transa, int64_t m, int64_t n,
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-// Row-major dgmm_batch maps to column-major by swapping the side and m/n.
-static inline side dgmm_flip_side(side left_right) {
-    return left_right == oneapi::math::side::left ? oneapi::math::side::right
-                                                  : oneapi::math::side::left;
-}
-
 #define DGMM_STRIDED_BATCH_LAUNCHER(TYPE)                                                          \
     void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,                     \
                     sycl::buffer<TYPE, 1>& a, int64_t lda, int64_t stride_a,                       \
                     sycl::buffer<TYPE, 1>& x, int64_t incx, int64_t stride_x,                      \
                     sycl::buffer<TYPE, 1>& c, int64_t ldc, int64_t stride_c, int64_t batch_size) { \
-        column_major::dgmm_batch(queue, dgmm_flip_side(left_right), n, m, a, lda, stride_a, x,      \
-                                 incx, stride_x, c, ldc, stride_c, batch_size);                     \
+        column_major::dgmm_batch(queue, dgmm_flip_side(left_right), n, m, a, lda, stride_a, x,     \
+                                 incx, stride_x, c, ldc, stride_c, batch_size);                    \
     }
 
 DGMM_STRIDED_BATCH_LAUNCHER(float)
@@ -1563,14 +1569,14 @@ sycl::event gemv_batch(sycl::queue& queue, transpose* transa, int64_t* m, int64_
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-#define DGMM_STRIDED_BATCH_LAUNCHER_USM(TYPE)                                                       \
-    sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,               \
-                           const TYPE* a, int64_t lda, int64_t stride_a, const TYPE* x,             \
-                           int64_t incx, int64_t stride_x, TYPE* c, int64_t ldc, int64_t stride_c,  \
-                           int64_t batch_size, const std::vector<sycl::event>& dependencies) {      \
-        return column_major::dgmm_batch(queue, dgmm_flip_side(left_right), n, m, a, lda, stride_a,  \
-                                        x, incx, stride_x, c, ldc, stride_c, batch_size,            \
-                                        dependencies);                                              \
+#define DGMM_STRIDED_BATCH_LAUNCHER_USM(TYPE)                                                      \
+    sycl::event dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,              \
+                           const TYPE* a, int64_t lda, int64_t stride_a, const TYPE* x,            \
+                           int64_t incx, int64_t stride_x, TYPE* c, int64_t ldc, int64_t stride_c, \
+                           int64_t batch_size, const std::vector<sycl::event>& dependencies) {     \
+        return column_major::dgmm_batch(queue, dgmm_flip_side(left_right), n, m, a, lda, stride_a, \
+                                        x, incx, stride_x, c, ldc, stride_c, batch_size,           \
+                                        dependencies);                                             \
     }
 
 DGMM_STRIDED_BATCH_LAUNCHER_USM(float)
@@ -1580,21 +1586,20 @@ DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>)
 
 #undef DGMM_STRIDED_BATCH_LAUNCHER_USM
 
-#define DGMM_GROUP_BATCH_LAUNCHER_USM(TYPE)                                                      \
+#define DGMM_GROUP_BATCH_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                       \
     sycl::event dgmm_batch(sycl::queue& queue, side* left_right, int64_t* m, int64_t* n,          \
                            const TYPE** a, int64_t* lda, const TYPE** x, int64_t* incx, TYPE** c, \
                            int64_t* ldc, int64_t group_count, int64_t* groupsize,                 \
                            const std::vector<sycl::event>& dependencies) {                        \
-        for (int64_t i = 0; i < group_count; i++)                                                 \
-            left_right[i] = dgmm_flip_side(left_right[i]);                                         \
-        return column_major::dgmm_batch(queue, left_right, n, m, a, lda, x, incx, c, ldc,         \
-                                        group_count, groupsize, dependencies);                    \
+        return column_major::dgmm_batch(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, left_right, n, m, \
+                                        a, lda, x, incx, c, ldc, group_count, groupsize,          \
+                                        dependencies, /*flip_side=*/true);                        \
     }
 
-DGMM_GROUP_BATCH_LAUNCHER_USM(float)
-DGMM_GROUP_BATCH_LAUNCHER_USM(double)
-DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<float>)
-DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<double>)
+DGMM_GROUP_BATCH_LAUNCHER_USM(float, cublasSdgmm_64)
+DGMM_GROUP_BATCH_LAUNCHER_USM(double, cublasDdgmm_64)
+DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<float>, cublasCdgmm_64)
+DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<double>, cublasZdgmm_64)
 
 #undef DGMM_GROUP_BATCH_LAUNCHER_USM
 

--- a/src/blas/backends/cublas/cublas_batch.cpp
+++ b/src/blas/backends/cublas/cublas_batch.cpp
@@ -118,7 +118,6 @@ inline void dgmm_batch(const char* func_name, Func func, sycl::queue& queue, sid
                        sycl::buffer<T, 1>& x, int64_t incx, int64_t stride_x, sycl::buffer<T, 1>& c,
                        int64_t ldc, int64_t stride_c, int64_t batch_size) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
-    overflow_check(m, n, lda, ldc, stride_a, stride_x, stride_c, batch_size);
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
@@ -131,9 +130,9 @@ inline void dgmm_batch(const char* func_name, Func func, sycl::queue& queue, sid
             cublasStatus_t err;
             auto mode = get_cublas_side_mode(left_right);
             for (int64_t i = 0; i < batch_size; i++) {
-                cublas_native_named_func(func_name, func, err, handle, mode, (int)m, (int)n,
-                                         a_ + i * stride_a, (int)lda, x_ + i * stride_x, (int)incx,
-                                         c_ + i * stride_c, (int)ldc);
+                cublas_native_named_func(func_name, func, err, handle, mode, m, n,
+                                         a_ + i * stride_a, lda, x_ + i * stride_x, incx,
+                                         c_ + i * stride_c, ldc);
             }
         });
     });
@@ -148,10 +147,10 @@ inline void dgmm_batch(const char* func_name, Func func, sycl::queue& queue, sid
                    incx, stride_x, c, ldc, stride_c, batch_size);                                  \
     }
 
-DGMM_STRIDED_BATCH_LAUNCHER(float, cublasSdgmm)
-DGMM_STRIDED_BATCH_LAUNCHER(double, cublasDdgmm)
-DGMM_STRIDED_BATCH_LAUNCHER(std::complex<float>, cublasCdgmm)
-DGMM_STRIDED_BATCH_LAUNCHER(std::complex<double>, cublasZdgmm)
+DGMM_STRIDED_BATCH_LAUNCHER(float, cublasSdgmm_64)
+DGMM_STRIDED_BATCH_LAUNCHER(double, cublasDdgmm_64)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<float>, cublasCdgmm_64)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<double>, cublasZdgmm_64)
 
 #undef DGMM_STRIDED_BATCH_LAUNCHER
 
@@ -573,7 +572,6 @@ inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& que
                               int64_t stride_c, int64_t batch_size,
                               const std::vector<sycl::event>& dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
-    overflow_check(m, n, lda, ldc, stride_a, stride_x, stride_c, batch_size);
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -587,9 +585,9 @@ inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& que
             cublasStatus_t err;
             auto mode = get_cublas_side_mode(left_right);
             for (int64_t i = 0; i < batch_size; i++) {
-                cublas_native_named_func(func_name, func, err, handle, mode, (int)m, (int)n,
-                                         a_ + i * stride_a, (int)lda, x_ + i * stride_x, (int)incx,
-                                         c_ + i * stride_c, (int)ldc);
+                cublas_native_named_func(func_name, func, err, handle, mode, m, n,
+                                         a_ + i * stride_a, lda, x_ + i * stride_x, incx,
+                                         c_ + i * stride_c, ldc);
             }
         });
     });
@@ -605,10 +603,10 @@ inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& que
                           stride_a, x, incx, stride_x, c, ldc, stride_c, batch_size, dependencies); \
     }
 
-DGMM_STRIDED_BATCH_LAUNCHER_USM(float, cublasSdgmm)
-DGMM_STRIDED_BATCH_LAUNCHER_USM(double, cublasDdgmm)
-DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>, cublasCdgmm)
-DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, cublasZdgmm)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(float, cublasSdgmm_64)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(double, cublasDdgmm_64)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>, cublasCdgmm_64)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, cublasZdgmm_64)
 
 #undef DGMM_STRIDED_BATCH_LAUNCHER_USM
 
@@ -619,9 +617,6 @@ inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& que
                               int64_t* incx, T** c, int64_t* ldc, int64_t group_count,
                               int64_t* groupsize, const std::vector<sycl::event>& dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
-    for (int64_t i = 0; i < group_count; i++) {
-        overflow_check(m[i], n[i], lda[i], ldc[i], groupsize[i]);
-    }
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -637,8 +632,8 @@ inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& que
                     auto a_ = reinterpret_cast<const cuDataType*>(a[offset + j]);
                     auto x_ = reinterpret_cast<const cuDataType*>(x[offset + j]);
                     auto c_ = reinterpret_cast<cuDataType*>(c[offset + j]);
-                    cublas_native_named_func(func_name, func, err, handle, mode, (int)m[i], (int)n[i],
-                                             a_, (int)lda[i], x_, (int)incx[i], c_, (int)ldc[i]);
+                    cublas_native_named_func(func_name, func, err, handle, mode, m[i], n[i], a_,
+                                             lda[i], x_, incx[i], c_, ldc[i]);
                 }
                 offset += groupsize[i];
             }
@@ -656,10 +651,10 @@ inline sycl::event dgmm_batch(const char* func_name, Func func, sycl::queue& que
                           incx, c, ldc, group_count, groupsize, dependencies);                    \
     }
 
-DGMM_GROUP_BATCH_LAUNCHER_USM(float, cublasSdgmm)
-DGMM_GROUP_BATCH_LAUNCHER_USM(double, cublasDdgmm)
-DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<float>, cublasCdgmm)
-DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<double>, cublasZdgmm)
+DGMM_GROUP_BATCH_LAUNCHER_USM(float, cublasSdgmm_64)
+DGMM_GROUP_BATCH_LAUNCHER_USM(double, cublasDdgmm_64)
+DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<float>, cublasCdgmm_64)
+DGMM_GROUP_BATCH_LAUNCHER_USM(std::complex<double>, cublasZdgmm_64)
 
 #undef DGMM_GROUP_BATCH_LAUNCHER_USM
 

--- a/src/blas/backends/rocblas/rocblas_batch.cpp
+++ b/src/blas/backends/rocblas/rocblas_batch.cpp
@@ -67,6 +67,13 @@ namespace oneapi {
 namespace math {
 namespace blas {
 namespace rocblas {
+
+// Row-major dgmm_batch maps to column-major by swapping the side and m/n.
+static inline side dgmm_flip_side(side left_right) {
+    return left_right == oneapi::math::side::left ? oneapi::math::side::right
+                                                  : oneapi::math::side::left;
+}
+
 namespace column_major {
 
 // Buffer APIs
@@ -797,11 +804,14 @@ DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zdgmm_strided_batc
 
 #undef DGMM_STRIDED_BATCH_LAUNCHER_USM
 
+// flip_side lets the row-major layer reverse each group's side without writing to
+// the caller's left_right array, which the spec defines as an input parameter.
 template <typename Func, typename T>
 inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side* left_right, int64_t* m,
                               int64_t* n, const T** a, int64_t* lda, const T** x, int64_t* incx,
                               T** c, int64_t* ldc, int64_t group_count, int64_t* group_size,
-                              const std::vector<sycl::event>& dependencies) {
+                              const std::vector<sycl::event>& dependencies,
+                              bool flip_side = false) {
     using rocDataType = typename RocEquivalentType<T>::Type;
 
     auto done = queue.submit([&](sycl::handler& cgh) {
@@ -815,9 +825,10 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side* left_right, i
                 auto** a_ = reinterpret_cast<const rocDataType**>(a);
                 auto** x_ = reinterpret_cast<const rocDataType**>(x);
                 auto** c_ = reinterpret_cast<rocDataType**>(c);
-                rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right[i]), m[i],
-                                    n[i], a_ + offset, lda[i], x_ + offset, incx[i], c_ + offset,
-                                    ldc[i], group_size[i]);
+                const auto side_i = flip_side ? dgmm_flip_side(left_right[i]) : left_right[i];
+                rocblas_native_func(func, err, handle, get_rocblas_side_mode(side_i), m[i], n[i],
+                                    a_ + offset, lda[i], x_ + offset, incx[i], c_ + offset, ldc[i],
+                                    group_size[i]);
                 offset += group_size[i];
             }
         });
@@ -1504,11 +1515,8 @@ inline void dgmm_batch(Func func, sycl::queue& queue, side left_right, int64_t m
                        sycl::buffer<T, 1>& a, int64_t lda, int64_t stridea, sycl::buffer<T, 1>& x,
                        int64_t incx, int64_t stridex, sycl::buffer<T, 1>& c, int64_t ldc,
                        int64_t stridec, int64_t batch_size) {
-    auto new_side = left_right == oneapi::math::side::left ? oneapi::math::side::right
-                                                           : oneapi::math::side::left;
-
-    column_major::dgmm_batch(func, queue, new_side, n, m, a, lda, stridea, x, incx, stridex, c, ldc,
-                             stridec, batch_size);
+    column_major::dgmm_batch(func, queue, dgmm_flip_side(left_right), n, m, a, lda, stridea, x,
+                             incx, stridex, c, ldc, stridec, batch_size);
 }
 
 #define DGMM_STRIDED_BATCH_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
@@ -1990,11 +1998,8 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side left_right, in
                               const T* a, int64_t lda, int64_t stridea, const T* x, int64_t incx,
                               int64_t stridex, T* c, int64_t ldc, int64_t stridec,
                               int64_t batch_size, const std::vector<sycl::event>& dependencies) {
-    auto new_side = left_right == oneapi::math::side::left ? oneapi::math::side::right
-                                                           : oneapi::math::side::left;
-
-    return column_major::dgmm_batch(func, queue, new_side, n, m, a, lda, stridea, x, incx, stridex,
-                                    c, ldc, stridec, batch_size, dependencies);
+    return column_major::dgmm_batch(func, queue, dgmm_flip_side(left_right), n, m, a, lda, stridea,
+                                    x, incx, stridex, c, ldc, stridec, batch_size, dependencies);
 }
 
 #define DGMM_STRIDED_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                   \
@@ -2018,14 +2023,8 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side* left_right, i
                               int64_t* n, const T** a, int64_t* lda, const T** x, int64_t* incx,
                               T** c, int64_t* ldc, int64_t group_count, int64_t* group_size,
                               const std::vector<sycl::event>& dependencies) {
-    for (int64_t i = 0; i < group_count; i++) {
-        const auto new_side = left_right[i] == oneapi::math::side::left ? oneapi::math::side::right
-                                                                        : oneapi::math::side::left;
-        left_right[i] = new_side;
-    }
-
     return column_major::dgmm_batch(func, queue, left_right, n, m, a, lda, x, incx, c, ldc,
-                                    group_count, group_size, dependencies);
+                                    group_count, group_size, dependencies, /*flip_side=*/true);
 }
 
 #define DGMM_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \

--- a/src/blas/backends/rocblas/rocblas_batch.cpp
+++ b/src/blas/backends/rocblas/rocblas_batch.cpp
@@ -192,7 +192,6 @@ inline void dgmm_batch(Func func, sycl::queue& queue, side left_right, int64_t m
                        int64_t incx, int64_t stridex, sycl::buffer<T, 1>& c, int64_t ldc,
                        int64_t stridec, int64_t batch_size) {
     using rocDataType = typename RocEquivalentType<T>::Type;
-    overflow_check(m, n, lda, ldc, incx, stridea, stridex, stridec, batch_size);
 
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
@@ -211,6 +210,7 @@ inline void dgmm_batch(Func func, sycl::queue& queue, side left_right, int64_t m
     });
 }
 
+// Use the ILP64 (_64) rocBLAS entry points so 64-bit dimensions are supported.
 #define DGMM_STRIDED_BATCH_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
     void dgmm_batch(sycl::queue& queue, side left_right, int64_t m, int64_t n,                     \
                     sycl::buffer<TYPE, 1>& a, int64_t lda, int64_t stridea,                        \
@@ -220,10 +220,10 @@ inline void dgmm_batch(Func func, sycl::queue& queue, side left_right, int64_t m
                    ldc, stridec, batch_size);                                                      \
     }
 
-DGMM_STRIDED_BATCH_LAUNCHER(float, rocblas_sdgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER(double, rocblas_ddgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER(std::complex<float>, rocblas_cdgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER(std::complex<double>, rocblas_zdgmm_strided_batched)
+DGMM_STRIDED_BATCH_LAUNCHER(float, rocblas_sdgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER(double, rocblas_ddgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<float>, rocblas_cdgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<double>, rocblas_zdgmm_strided_batched_64)
 
 #undef DGMM_STRIDED_BATCH_LAUNCHER
 
@@ -763,7 +763,6 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side left_right, in
                               int64_t stridex, T* c, int64_t ldc, int64_t stridec,
                               int64_t batch_size, const std::vector<sycl::event>& dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
-    overflow_check(m, n, incx, stridea, stridex, stridec, batch_size);
 
     auto done = queue.submit([&](sycl::handler& cgh) {
         cgh.depends_on(dependencies);
@@ -791,10 +790,10 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side left_right, in
                           stridex, c, ldc, stridec, batch_size, dependencies);                   \
     }
 
-DGMM_STRIDED_BATCH_LAUNCHER_USM(float, rocblas_sdgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER_USM(double, rocblas_ddgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>, rocblas_cdgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zdgmm_strided_batched)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(float, rocblas_sdgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(double, rocblas_ddgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>, rocblas_cdgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zdgmm_strided_batched_64)
 
 #undef DGMM_STRIDED_BATCH_LAUNCHER_USM
 
@@ -804,9 +803,6 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side* left_right, i
                               T** c, int64_t* ldc, int64_t group_count, int64_t* group_size,
                               const std::vector<sycl::event>& dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
-    for (int64_t i = 0; i < group_count; i++) {
-        overflow_check(m[i], n[i], lda[i], ldc[i], incx[i], group_size[i]);
-    }
 
     auto done = queue.submit([&](sycl::handler& cgh) {
         cgh.depends_on(dependencies);
@@ -819,9 +815,9 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side* left_right, i
                 auto** a_ = reinterpret_cast<const rocDataType**>(a);
                 auto** x_ = reinterpret_cast<const rocDataType**>(x);
                 auto** c_ = reinterpret_cast<rocDataType**>(c);
-                rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right[i]),
-                                    (int)m[i], (int)n[i], a_ + offset, (int)lda[i], x_ + offset,
-                                    (int)incx[i], c_ + offset, (int)ldc[i], (int)group_size[i]);
+                rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right[i]), m[i],
+                                    n[i], a_ + offset, lda[i], x_ + offset, incx[i], c_ + offset,
+                                    ldc[i], group_size[i]);
                 offset += group_size[i];
             }
         });
@@ -839,10 +835,10 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side* left_right, i
                           group_count, group_size, dependencies);                                 \
     }
 
-DGMM_BATCH_LAUNCHER_USM(float, rocblas_sdgmm_batched)
-DGMM_BATCH_LAUNCHER_USM(double, rocblas_ddgmm_batched)
-DGMM_BATCH_LAUNCHER_USM(std::complex<float>, rocblas_cdgmm_batched)
-DGMM_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zdgmm_batched)
+DGMM_BATCH_LAUNCHER_USM(float, rocblas_sdgmm_batched_64)
+DGMM_BATCH_LAUNCHER_USM(double, rocblas_ddgmm_batched_64)
+DGMM_BATCH_LAUNCHER_USM(std::complex<float>, rocblas_cdgmm_batched_64)
+DGMM_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zdgmm_batched_64)
 
 #undef DGMM_BATCH_LAUNCHER
 
@@ -1524,10 +1520,10 @@ inline void dgmm_batch(Func func, sycl::queue& queue, side left_right, int64_t m
                    ldc, stridec, batch_size);                                                      \
     }
 
-DGMM_STRIDED_BATCH_LAUNCHER(float, rocblas_sdgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER(double, rocblas_ddgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER(std::complex<float>, rocblas_cdgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER(std::complex<double>, rocblas_zdgmm_strided_batched)
+DGMM_STRIDED_BATCH_LAUNCHER(float, rocblas_sdgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER(double, rocblas_ddgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<float>, rocblas_cdgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER(std::complex<double>, rocblas_zdgmm_strided_batched_64)
 
 #undef DGMM_STRIDED_BATCH_LAUNCHER
 
@@ -2010,10 +2006,10 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side left_right, in
                           stridex, c, ldc, stridec, batch_size, dependencies);                   \
     }
 
-DGMM_STRIDED_BATCH_LAUNCHER_USM(float, rocblas_sdgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER_USM(double, rocblas_ddgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>, rocblas_cdgmm_strided_batched)
-DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zdgmm_strided_batched)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(float, rocblas_sdgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(double, rocblas_ddgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>, rocblas_cdgmm_strided_batched_64)
+DGMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zdgmm_strided_batched_64)
 
 #undef DGMM_STRIDED_BATCH_LAUNCHER_USM
 
@@ -2041,10 +2037,10 @@ inline sycl::event dgmm_batch(Func func, sycl::queue& queue, side* left_right, i
                           group_count, group_size, dependencies);                                 \
     }
 
-DGMM_BATCH_LAUNCHER_USM(float, rocblas_sdgmm_batched)
-DGMM_BATCH_LAUNCHER_USM(double, rocblas_ddgmm_batched)
-DGMM_BATCH_LAUNCHER_USM(std::complex<float>, rocblas_cdgmm_batched)
-DGMM_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zdgmm_batched)
+DGMM_BATCH_LAUNCHER_USM(float, rocblas_sdgmm_batched_64)
+DGMM_BATCH_LAUNCHER_USM(double, rocblas_ddgmm_batched_64)
+DGMM_BATCH_LAUNCHER_USM(std::complex<float>, rocblas_cdgmm_batched_64)
+DGMM_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zdgmm_batched_64)
 
 #undef DGMM_BATCH_LAUNCHER
 

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
@@ -191,6 +191,10 @@ TEST_P(DgmmBatchStrideTests, RealSinglePrecision) {
                                   oneapi::math::side::left, -2, 5));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                   oneapi::math::side::left, 1, 5));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                  oneapi::math::side::right, 3, 5));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                  oneapi::math::side::left, -1, 5));
 }
 
 TEST_P(DgmmBatchStrideTests, RealDoublePrecision) {
@@ -208,6 +212,10 @@ TEST_P(DgmmBatchStrideTests, RealDoublePrecision) {
                                    oneapi::math::side::left, -2, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::math::side::left, 1, 5));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                   oneapi::math::side::right, 3, 5));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                   oneapi::math::side::left, -1, 5));
 }
 
 TEST_P(DgmmBatchStrideTests, ComplexSinglePrecision) {
@@ -223,6 +231,10 @@ TEST_P(DgmmBatchStrideTests, ComplexSinglePrecision) {
                                                 oneapi::math::side::left, -2, 5));
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 oneapi::math::side::left, 1, 5));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                oneapi::math::side::right, 3, 5));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                oneapi::math::side::left, -1, 5));
 }
 
 TEST_P(DgmmBatchStrideTests, ComplexDoublePrecision) {
@@ -240,6 +252,10 @@ TEST_P(DgmmBatchStrideTests, ComplexDoublePrecision) {
                                                  oneapi::math::side::left, -2, 5));
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::math::side::left, 1, 5));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 oneapi::math::side::right, 3, 5));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 oneapi::math::side::left, -1, 5));
 }
 
 INSTANTIATE_TEST_SUITE_P(DgmmBatchStrideTestSuite, DgmmBatchStrideTests,

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
@@ -196,6 +196,10 @@ TEST_P(DgmmBatchStrideUsmTests, RealSinglePrecision) {
                                   oneapi::math::side::left, -2, 5));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                   oneapi::math::side::left, 1, 5));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                  oneapi::math::side::right, 3, 5));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                  oneapi::math::side::left, -1, 5));
 }
 
 TEST_P(DgmmBatchStrideUsmTests, RealDoublePrecision) {
@@ -213,6 +217,10 @@ TEST_P(DgmmBatchStrideUsmTests, RealDoublePrecision) {
                                    oneapi::math::side::left, -2, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::math::side::left, 1, 5));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                   oneapi::math::side::right, 3, 5));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                   oneapi::math::side::left, -1, 5));
 }
 
 TEST_P(DgmmBatchStrideUsmTests, ComplexSinglePrecision) {
@@ -228,6 +236,10 @@ TEST_P(DgmmBatchStrideUsmTests, ComplexSinglePrecision) {
                                                 oneapi::math::side::left, -2, 5));
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 oneapi::math::side::left, 1, 5));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                oneapi::math::side::right, 3, 5));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                oneapi::math::side::left, -1, 5));
 }
 
 TEST_P(DgmmBatchStrideUsmTests, ComplexDoublePrecision) {
@@ -245,6 +257,10 @@ TEST_P(DgmmBatchStrideUsmTests, ComplexDoublePrecision) {
                                                  oneapi::math::side::left, -2, 5));
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::math::side::left, 1, 5));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 oneapi::math::side::right, 3, 5));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 oneapi::math::side::left, -1, 5));
 }
 
 INSTANTIATE_TEST_SUITE_P(DgmmBatchStrideUsmTestSuite, DgmmBatchStrideUsmTests,

--- a/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
@@ -289,25 +289,37 @@ class DgmmBatchUsmTests
         : public ::testing::TestWithParam<std::tuple<sycl::device*, oneapi::math::layout>> {};
 
 TEST_P(DgmmBatchUsmTests, RealSinglePrecision) {
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 10));
 }
 
 TEST_P(DgmmBatchUsmTests, RealDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 10));
 }
 
 TEST_P(DgmmBatchUsmTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP(
+        test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1));
+    EXPECT_TRUEORSKIP(
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
+    EXPECT_TRUEORSKIP(
+        test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 10));
 }
 
 TEST_P(DgmmBatchUsmTests, ComplexDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
+        test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1));
+    EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
+    EXPECT_TRUEORSKIP(
+        test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 10));
 }
 
 INSTANTIATE_TEST_SUITE_P(DgmmBatchUsmTestSuite, DgmmBatchUsmTests,

--- a/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
@@ -185,6 +185,9 @@ int test(device* dev, oneapi::math::layout layout, int64_t group_count) {
 
     // Call DPC++ DGMM_BATCH.
 
+    // left_right is an input parameter, so the backend must leave it untouched.
+    std::vector<oneapi::math::side> left_right_orig(left_right.begin(), left_right.end());
+
     try {
 #ifdef CALL_RT_API
         switch (layout) {
@@ -254,6 +257,11 @@ int test(device* dev, oneapi::math::layout layout, int64_t group_count) {
     }
 
     bool good = true;
+    if (!std::equal(left_right_orig.begin(), left_right_orig.end(), left_right.begin())) {
+        std::cout << "Error: DGMM_BATCH overwrote the input left_right array\n";
+        good = false;
+    }
+
     // Compare the results of reference implementation and DPC++ implementation.
     idx = 0;
     for (i = 0; i < group_count; i++) {


### PR DESCRIPTION
## Summary

`dgmm_batch` was unimplemented (threw `unimplemented`) in the cuBLAS backend. As noted in #562, cuBLAS provides only the non-batched `cublas<t>dgmm` — there is **no** strided/batched `dgmm` in any CUDA library (verified across cuBLAS, cuBLASLt, cuBLASXt, cuSPARSE headers; only `cublasSdgmm/Ddgmm/Cdgmm/Zdgmm` and their `_64` twins exist). This PR implements `dgmm_batch` for the cuBLAS backend by looping over `cublas<t>dgmm`.

- Implements column-major **buffer strided**, **USM strided**, and **USM group** `dgmm_batch`
- Types: `float`, `double`, `complex<float>`, `complex<double>`
- Row-major maps to column-major by flipping `side` and swapping `m`/`n` (same approach as the rocBLAS backend)
- Handles negative `incx` via the standard BLAS start-at-end convention

## Tests

Extends the shared `dgmm_batch` tests for stronger coverage:
- strided (buffer + USM): adds `incx = 3` and `incx = -1` cases
- group (USM): adds `group_count = 1` and `group_count = 10` cases

## Test plan

Verified on an NVIDIA RTX PRO 6000 Blackwell (sm_120), CUDA 13.3 / cuBLAS 13.6, DPC++:

- [x] `test_main_blas_ct --gtest_filter=*Dgmm*` → all pass (col/row major, all 4 types)
- [x] `test_main_blas_rt --gtest_filter=*Dgmm*` → all pass
- [x] Covers `DgmmBatchStride`, `DgmmBatchStrideUsm`, `DgmmBatchUsm` (group API)

Closes #562.
