### PR TITLE
[cmake][docs] Handle AMD code object ABI mismatch for ROCm < 6.3

### DIFF
--- a/cmake/FindCompiler.cmake
+++ b/cmake/FindCompiler.cmake
@@ -57,6 +57,32 @@ if(is_dpcpp)
       list(APPEND UNIX_INTERFACE_LINK_OPTIONS
         -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend 
 	--offload-arch=${HIP_TARGETS})
+      # Recent DPC++/LLVM defaults to AMD code object ABI version 6, which is
+      # only supported by ROCm 6.3+. When building against an older ROCm, fall
+      # back to code object version 5 so the ROCm device library can be found.
+      # See https://github.com/uxlfoundation/oneMath/issues/687
+      if(NOT CMAKE_CXX_FLAGS MATCHES "-mcode-object-version")
+        set(_onemath_rocm_version_file "")
+        foreach(_onemath_rocm_root "$ENV{ROCM_PATH}" "$ENV{HIPROOT}" "/opt/rocm")
+          if(_onemath_rocm_root AND EXISTS "${_onemath_rocm_root}/.info/version")
+            set(_onemath_rocm_version_file "${_onemath_rocm_root}/.info/version")
+            break()
+          endif()
+        endforeach()
+        if(_onemath_rocm_version_file)
+          file(READ "${_onemath_rocm_version_file}" _onemath_rocm_version)
+          string(STRIP "${_onemath_rocm_version}" _onemath_rocm_version)
+          if(_onemath_rocm_version MATCHES "^([0-9]+)\\.([0-9]+)")
+            set(_onemath_rocm_ver "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+            if(_onemath_rocm_ver VERSION_LESS "6.3")
+              message(STATUS "Detected ROCm ${_onemath_rocm_ver} (< 6.3); "
+                "adding -mcode-object-version=5 for AMD targets")
+              list(APPEND UNIX_INTERFACE_COMPILE_OPTIONS -mcode-object-version=5)
+              list(APPEND UNIX_INTERFACE_LINK_OPTIONS -mcode-object-version=5)
+            endif()
+          endif()
+        endif()
+      endif()
     endif()
     if(ENABLE_CURAND_BACKEND OR ENABLE_CUSOLVER_BACKEND OR ENABLE_CUSPARSE_BACKEND OR ENABLE_ROCBLAS_BACKEND
 	    OR ENABLE_ROCRAND_BACKEND OR ENABLE_ROCSOLVER_BACKEND OR ENABLE_ROCSPARSE_BACKEND)

--- a/docs/building_the_project_with_dpcpp.rst
+++ b/docs/building_the_project_with_dpcpp.rst
@@ -242,6 +242,22 @@ A few often-used architectures are listed below:
 For a host with ROCm installed, the device architecture can be retrieved via the
 ``rocminfo`` tool. The architecture will be displayed in the ``Name:`` row.
 
+.. note::
+
+  Recent versions of the DPC++/LLVM compiler default to AMD code object ABI
+  version 6, which is only supported by ROCm 6.3 and higher. When building
+  against ROCm < 6.3 this results in an error such as::
+
+    clang++: error: cannot find ROCm device library for ABI version 6, which
+    requires ROCm 6.3 or higher
+
+  This is a toolchain (compiler/ROCm) compatibility issue and is not specific to
+  oneMath: it affects any HIP or SYCL-on-AMD application built with a recent
+  enough compiler. To build with ROCm < 6.3, downgrade the code object version
+  by adding ``-mcode-object-version=5`` to the compiler flags, for example::
+
+    cmake <build options> -DCMAKE_CXX_FLAGS="-mcode-object-version=5" ..
+
 .. _build_for_other_SYCL_devices:
 
 Building for other SYCL devices


### PR DESCRIPTION
## Summary
Recent DPC++/LLVM defaults to AMD code object ABI version 6, which only ROCm 6.3+ supports, so building any domain against an older ROCm fails with `cannot find ROCm device library for ABI version 6` (#687).

- `cmake/FindCompiler.cmake`: auto-append `-mcode-object-version=5` to the amdgcn compile/link options when ROCm < 6.3 is detected via `.info/version` (`ROCM_PATH` / `HIPROOT` / `/opt/rocm`), skipped if the user already set the flag.
- `docs/building_the_project_with_dpcpp.rst`: document the toolchain issue and the manual `-DCMAKE_CXX_FLAGS="-mcode-object-version=5"` workaround.

## Test plan
- Reproduced the exact error targeting `amdgcn` against ROCm 6.2.4; confirmed `-mcode-object-version=5` compiles cleanly (exit 0).
- Exercised the real `FindCompiler.cmake` end-to-end: flag added for ROCm 6.2.4/6.0.3, absent for 6.3.4/7.2.4, opt-out honored when user sets the flag, safe fall-through when no version file is found.

Fixes #687