### PR TITLE
[lapack][cusolver] Use the 64-bit pivot API for getrf and getrs

### DIFF
--- a/src/lapack/backends/cusolver/cusolver_batch.cpp
+++ b/src/lapack/backends/cusolver/cusolver_batch.cpp
@@ -184,6 +184,66 @@ GETRI_STRIDED_BATCH_LAUNCHER(std::complex<double>, cublasZgetriBatched)
 
 #undef GETRI_STRIDED_BATCH_LAUNCHER
 
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+template <typename T>
+inline void getrs_batch(const char* func_name, sycl::queue& queue, oneapi::math::transpose trans,
+                        std::int64_t n, std::int64_t nrhs, sycl::buffer<T>& a, std::int64_t lda,
+                        std::int64_t stride_a, sycl::buffer<std::int64_t>& ipiv,
+                        std::int64_t stride_ipiv, sycl::buffer<T>& b, std::int64_t ldb,
+                        std::int64_t stride_b, std::int64_t batch_size, sycl::buffer<T>& scratchpad,
+                        std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+
+    queue.submit([&](sycl::handler& cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto ipiv_acc = ipiv.template get_access<sycl::access::mode::read>(cgh);
+        auto b_acc = b.template get_access<sycl::access::mode::write>(cgh);
+
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType*>(a_acc);
+            auto ipiv_ = sc.get_mem<std::int64_t*>(ipiv_acc);
+            auto b_ = sc.get_mem<cuDataType*>(b_acc);
+            cusolverStatus_t err;
+            CusolverDnParams params;
+            constexpr cudaDataType data_type = CudaDataType<T>::Type;
+
+            // Does not use scratch so call cuSolver asynchronously and sync at end
+            for (int64_t i = 0; i < batch_size; ++i) {
+                CUSOLVER_ERROR_FUNC_T(func_name, cusolverDnXgetrs, err, handle, params.get(),
+                                      get_cublas_operation(trans), n, nrhs, data_type,
+                                      a_ + stride_a * i, lda, ipiv_ + stride_ipiv * i, data_type,
+                                      b_ + stride_b * i, ldb, nullptr);
+            }
+#ifndef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+            CUSOLVER_SYNC(err, handle)
+#endif
+        });
+    });
+}
+
+#define GETRS_STRIDED_BATCH_LAUNCHER(TYPE)                                                    \
+    void getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n,       \
+                     std::int64_t nrhs, sycl::buffer<TYPE>& a, std::int64_t lda,              \
+                     std::int64_t stride_a, sycl::buffer<std::int64_t>& ipiv,                 \
+                     std::int64_t stride_ipiv, sycl::buffer<TYPE>& b, std::int64_t ldb,       \
+                     std::int64_t stride_b, std::int64_t batch_size,                          \
+                     sycl::buffer<TYPE>& scratchpad, std::int64_t scratchpad_size) {          \
+        return getrs_batch<TYPE>("cusolverDnXgetrs", queue, trans, n, nrhs, a, lda, stride_a, \
+                                 ipiv, stride_ipiv, b, ldb, stride_b, batch_size, scratchpad, \
+                                 scratchpad_size);                                            \
+    }
+
+GETRS_STRIDED_BATCH_LAUNCHER(float)
+GETRS_STRIDED_BATCH_LAUNCHER(double)
+GETRS_STRIDED_BATCH_LAUNCHER(std::complex<float>)
+GETRS_STRIDED_BATCH_LAUNCHER(std::complex<double>)
+
+#undef GETRS_STRIDED_BATCH_LAUNCHER
+
+#else // no 64-bit pivot API: narrow the pivots into a temporary 32-bit array
+
 template <typename Func, typename T>
 inline void getrs_batch(const char* func_name, Func func, sycl::queue& queue,
                         oneapi::math::transpose trans, std::int64_t n, std::int64_t nrhs,
@@ -254,6 +314,66 @@ GETRS_STRIDED_BATCH_LAUNCHER(std::complex<double>, cusolverDnZgetrs)
 
 #undef GETRS_STRIDED_BATCH_LAUNCHER
 
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+template <typename T>
+inline void getrf_batch(const char* func_name, sycl::queue& queue, std::int64_t m, std::int64_t n,
+                        sycl::buffer<T>& a, std::int64_t lda, std::int64_t stride_a,
+                        sycl::buffer<std::int64_t>& ipiv, std::int64_t stride_ipiv,
+                        std::int64_t batch_size, sycl::buffer<T>& scratchpad,
+                        std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+
+    sycl::buffer<int> devInfo{ batch_size };
+
+    queue.submit([&](sycl::handler& cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto ipiv_acc = ipiv.template get_access<sycl::access::mode::write>(cgh);
+        auto devInfo_acc = devInfo.template get_access<sycl::access::mode::write>(cgh);
+        auto scratch_acc = scratchpad.template get_access<sycl::access::mode::write>(cgh);
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType*>(a_acc);
+            auto ipiv_ = sc.get_mem<std::int64_t*>(ipiv_acc);
+            auto devInfo_ = sc.get_mem<int*>(devInfo_acc);
+            auto scratch_ = sc.get_mem<cuDataType*>(scratch_acc);
+            CusolverDnParams params;
+            size_t device_bytes, host_bytes;
+            cusolver_xgetrf_buffer_size<T>(handle, params.get(), m, n, lda, &device_bytes,
+                                           &host_bytes);
+
+            // Uses scratch so sync between each cuSolver call
+            for (std::int64_t i = 0; i < batch_size; ++i) {
+                cusolver_xgetrf<T>(func_name, handle, params.get(), m, n, a_ + stride_a * i, lda,
+                                   ipiv_ + stride_ipiv * i, scratch_, scratchpad_size * sizeof(T),
+                                   host_bytes, devInfo_ + i);
+            }
+        });
+    });
+
+    lapack_info_check(queue, devInfo, __func__, func_name, batch_size);
+}
+
+#define GETRF_STRIDED_BATCH_LAUNCHER(TYPE)                                                      \
+    void getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<TYPE>& a, \
+                     std::int64_t lda, std::int64_t stride_a, sycl::buffer<std::int64_t>& ipiv, \
+                     std::int64_t stride_ipiv, std::int64_t batch_size,                         \
+                     sycl::buffer<TYPE>& scratchpad, std::int64_t scratchpad_size) {            \
+        return getrf_batch<TYPE>("cusolverDnXgetrf", queue, m, n, a, lda, stride_a, ipiv,       \
+                                 stride_ipiv, batch_size, scratchpad, scratchpad_size);         \
+    }
+
+GETRF_STRIDED_BATCH_LAUNCHER(float)
+GETRF_STRIDED_BATCH_LAUNCHER(double)
+GETRF_STRIDED_BATCH_LAUNCHER(std::complex<float>)
+GETRF_STRIDED_BATCH_LAUNCHER(std::complex<double>)
+
+#undef GETRF_STRIDED_BATCH_LAUNCHER
+
+#else // no 64-bit pivot API: factorise into a temporary 32-bit array and widen it
+
 template <typename Func, typename T>
 inline void getrf_batch(const char* func_name, Func func, sycl::queue& queue, std::int64_t m,
                         std::int64_t n, sycl::buffer<T>& a, std::int64_t lda, std::int64_t stride_a,
@@ -318,6 +438,8 @@ GETRF_STRIDED_BATCH_LAUNCHER(std::complex<float>, cusolverDnCgetrf)
 GETRF_STRIDED_BATCH_LAUNCHER(std::complex<double>, cusolverDnZgetrf)
 
 #undef GETRF_STRIDED_BATCH_LAUNCHER
+
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
 
 template <typename Func, typename T>
 inline void orgqr_batch(const char* func_name, Func func, sycl::queue& queue, std::int64_t m,
@@ -635,6 +757,129 @@ GEQRF_BATCH_LAUNCHER_USM(std::complex<double>, cusolverDnZgeqrf)
 
 #undef GEQRF_BATCH_LAUNCHER_USM
 
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+template <typename T>
+inline sycl::event getrf_batch(const char* func_name, sycl::queue& queue, std::int64_t m,
+                               std::int64_t n, T* a, std::int64_t lda, std::int64_t stride_a,
+                               std::int64_t* ipiv, std::int64_t stride_ipiv,
+                               std::int64_t batch_size, T* scratchpad, std::int64_t scratchpad_size,
+                               const std::vector<sycl::event>& dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+
+    int* devInfo = (int*)malloc_device(sizeof(int) * batch_size, queue);
+
+    auto done = queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType*>(a);
+            auto devInfo_ = reinterpret_cast<int*>(devInfo);
+            auto scratchpad_ = reinterpret_cast<cuDataType*>(scratchpad);
+            CusolverDnParams params;
+            size_t device_bytes, host_bytes;
+            cusolver_xgetrf_buffer_size<T>(handle, params.get(), m, n, lda, &device_bytes,
+                                           &host_bytes);
+
+            // Uses scratch so sync between each cuSolver call
+            for (int64_t i = 0; i < batch_size; ++i) {
+                cusolver_xgetrf<T>(func_name, handle, params.get(), m, n, a_ + stride_a * i, lda,
+                                   ipiv + stride_ipiv * i, scratchpad_, scratchpad_size * sizeof(T),
+                                   host_bytes, devInfo_ + i);
+            }
+        });
+    });
+
+    // lapack_info_check calls queue.wait()
+    lapack_info_check(queue, devInfo, __func__, func_name, batch_size);
+    sycl::free(devInfo, queue);
+
+    return done;
+}
+
+#define GETRF_STRIDED_BATCH_LAUNCHER_USM(TYPE)                                                   \
+    sycl::event getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, TYPE* a,         \
+                            std::int64_t lda, std::int64_t stride_a, std::int64_t* ipiv,         \
+                            std::int64_t stride_ipiv, std::int64_t batch_size, TYPE* scratchpad, \
+                            std::int64_t scratchpad_size,                                        \
+                            const std::vector<sycl::event>& dependencies) {                      \
+        return getrf_batch<TYPE>("cusolverDnXgetrf", queue, m, n, a, lda, stride_a, ipiv,        \
+                                 stride_ipiv, batch_size, scratchpad, scratchpad_size,           \
+                                 dependencies);                                                  \
+    }
+
+GETRF_STRIDED_BATCH_LAUNCHER_USM(float)
+GETRF_STRIDED_BATCH_LAUNCHER_USM(double)
+GETRF_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>)
+GETRF_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>)
+
+#undef GETRF_STRIDED_BATCH_LAUNCHER_USM
+
+template <typename T>
+inline sycl::event getrf_batch(const char* func_name, sycl::queue& queue, std::int64_t* m,
+                               std::int64_t* n, T** a, std::int64_t* lda, std::int64_t** ipiv,
+                               std::int64_t group_count, std::int64_t* group_sizes, T* scratchpad,
+                               std::int64_t scratchpad_size,
+                               const std::vector<sycl::event>& dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+
+    int64_t batch_size = 0;
+    for (int64_t i = 0; i < group_count; ++i)
+        batch_size += group_sizes[i];
+
+    int* devInfo = (int*)malloc_device(sizeof(int) * batch_size, queue);
+
+    auto done = queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType**>(a);
+            auto scratch_ = reinterpret_cast<cuDataType*>(scratchpad);
+            int64_t global_id = 0;
+            CusolverDnParams params;
+
+            // Uses scratch so sync between each cuSolver call
+            for (int64_t group_id = 0; group_id < group_count; ++group_id) {
+                size_t device_bytes, host_bytes;
+                cusolver_xgetrf_buffer_size<T>(handle, params.get(), m[group_id], n[group_id],
+                                               lda[group_id], &device_bytes, &host_bytes);
+                for (int64_t local_id = 0; local_id < group_sizes[group_id];
+                     ++local_id, ++global_id) {
+                    cusolver_xgetrf<T>(func_name, handle, params.get(), m[group_id], n[group_id],
+                                       a_[global_id], lda[group_id], ipiv[global_id], scratch_,
+                                       scratchpad_size * sizeof(T), host_bytes,
+                                       devInfo + global_id);
+                }
+            }
+        });
+    });
+
+    // lapack_info_check calls queue.wait()
+    lapack_info_check(queue, devInfo, __func__, func_name, batch_size);
+    sycl::free(devInfo, queue);
+
+    return done;
+}
+
+#define GETRF_BATCH_LAUNCHER_USM(TYPE)                                                        \
+    sycl::event getrf_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, TYPE** a,   \
+                            std::int64_t* lda, std::int64_t** ipiv, std::int64_t group_count, \
+                            std::int64_t* group_sizes, TYPE* scratchpad,                      \
+                            std::int64_t scratchpad_size,                                     \
+                            const std::vector<sycl::event>& dependencies) {                   \
+        return getrf_batch<TYPE>("cusolverDnXgetrf", queue, m, n, a, lda, ipiv, group_count,  \
+                                 group_sizes, scratchpad, scratchpad_size, dependencies);     \
+    }
+
+GETRF_BATCH_LAUNCHER_USM(float)
+GETRF_BATCH_LAUNCHER_USM(double)
+GETRF_BATCH_LAUNCHER_USM(std::complex<float>)
+GETRF_BATCH_LAUNCHER_USM(std::complex<double>)
+
+#undef GETRF_BATCH_LAUNCHER_USM
+
+#else // no 64-bit pivot API: factorise into a temporary 32-bit array and widen it
+
 template <typename Func, typename T>
 inline sycl::event getrf_batch(const char* func_name, Func func, sycl::queue& queue, std::int64_t m,
                                std::int64_t n, T* a, std::int64_t lda, std::int64_t stride_a,
@@ -804,7 +1049,9 @@ GETRF_BATCH_LAUNCHER_USM(double, cusolverDnDgetrf)
 GETRF_BATCH_LAUNCHER_USM(std::complex<float>, cusolverDnCgetrf)
 GETRF_BATCH_LAUNCHER_USM(std::complex<double>, cusolverDnZgetrf)
 
-#undef GETRS_BATCH_LAUNCHER_USM
+#undef GETRF_BATCH_LAUNCHER_USM
+
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
 
 template <typename Func, typename T>
 sycl::event getri_batch(const char* func_name, Func func, sycl::queue& queue, std::int64_t n, T* a,
@@ -816,8 +1063,12 @@ sycl::event getri_batch(const char* func_name, Func func, sycl::queue& queue, st
 
     overflow_check(n, lda, stride_a, stride_ipiv, batch_size, scratchpad_size);
 
+    // cublas<t>getriBatched has no 64-bit pivot counterpart, so a 32-bit array is unavoidable.
+    // It is carved out of the tail of the scratchpad (see getri_batch_scratchpad_size), which
+    // avoids both a separate allocation and the host synchronisation to release it.
     std::uint64_t ipiv32_size = n * batch_size;
-    int* ipiv32 = sycl::malloc_device<int>(ipiv32_size, queue);
+    int* ipiv32 = reinterpret_cast<int*>(scratchpad + scratchpad_size -
+                                         pivot32_scratchpad_size<T>(ipiv32_size));
     int* devInfo = sycl::malloc_device<int>(batch_size, queue);
 
     sycl::event done_casting = queue.submit([&](sycl::handler& cgh) {
@@ -879,18 +1130,21 @@ sycl::event getri_batch(const char* func_name, Func func, sycl::queue& queue, st
             [=](sycl::id<1> index) { a[index] = scratchpad[index]; });
     });
 
+    // Chained onto copy1 so that the returned event covers both copies
     auto copy2 = queue.submit([&](sycl::handler& cgh) {
-        cgh.depends_on(done);
+        cgh.depends_on(copy1);
         cgh.parallel_for(
             sycl::range<1>{ static_cast<size_t>(ipiv32_size) }, [=](sycl::id<1> index) {
                 ipiv[(index / n) * stride_ipiv + index % n] = static_cast<int64_t>(ipiv32[index]);
             });
     });
-    copy1.wait();
-    copy2.wait();
-    sycl::free(ipiv32, queue);
-    sycl::free(devInfo, queue);
-    return done;
+
+    queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(copy2);
+        cgh.host_task([=](sycl::interop_handle ih) { sycl::free(devInfo, queue); });
+    });
+
+    return copy2;
 }
 
 #define GETRI_BATCH_LAUNCHER_USM(TYPE, CUSOLVER_ROUTINE)                                          \
@@ -935,6 +1189,121 @@ sycl::event getri_batch(sycl::queue& queue, std::int64_t* n, std::complex<double
                         const std::vector<sycl::event>& dependencies) {
     throw unimplemented("lapack", "getri_batch");
 }
+
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+template <typename T>
+inline sycl::event getrs_batch(const char* func_name, sycl::queue& queue,
+                               oneapi::math::transpose trans, std::int64_t n, std::int64_t nrhs,
+                               T* a, std::int64_t lda, std::int64_t stride_a, std::int64_t* ipiv,
+                               std::int64_t stride_ipiv, T* b, std::int64_t ldb,
+                               std::int64_t stride_b, std::int64_t batch_size, T* scratchpad,
+                               std::int64_t scratchpad_size,
+                               const std::vector<sycl::event>& dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+
+    return queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType*>(a);
+            auto b_ = reinterpret_cast<cuDataType*>(b);
+            cusolverStatus_t err;
+            CusolverDnParams params;
+            constexpr cudaDataType data_type = CudaDataType<T>::Type;
+
+            // Does not use scratch so call cuSolver asynchronously and sync at end
+            for (int64_t i = 0; i < batch_size; ++i) {
+                CUSOLVER_ERROR_FUNC_T(func_name, cusolverDnXgetrs, err, handle, params.get(),
+                                      get_cublas_operation(trans), n, nrhs, data_type,
+                                      a_ + stride_a * i, lda, ipiv + stride_ipiv * i, data_type,
+                                      b_ + stride_b * i, ldb, nullptr);
+            }
+#ifndef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+            CUSOLVER_SYNC(err, handle)
+#endif
+        });
+    });
+}
+
+#define GETRS_STRIDED_BATCH_LAUNCHER_USM(TYPE)                                                   \
+    sycl::event getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n,   \
+                            std::int64_t nrhs, TYPE* a, std::int64_t lda, std::int64_t stride_a, \
+                            std::int64_t* ipiv, std::int64_t stride_ipiv, TYPE* b,               \
+                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,    \
+                            TYPE* scratchpad, std::int64_t scratchpad_size,                      \
+                            const std::vector<sycl::event>& dependencies) {                      \
+        return getrs_batch<TYPE>("cusolverDnXgetrs", queue, trans, n, nrhs, a, lda, stride_a,    \
+                                 ipiv, stride_ipiv, b, ldb, stride_b, batch_size, scratchpad,    \
+                                 scratchpad_size, dependencies);                                 \
+    }
+
+GETRS_STRIDED_BATCH_LAUNCHER_USM(float)
+GETRS_STRIDED_BATCH_LAUNCHER_USM(double)
+GETRS_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>)
+GETRS_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>)
+
+#undef GETRS_STRIDED_BATCH_LAUNCHER_USM
+
+template <typename T>
+inline sycl::event getrs_batch(const char* func_name, sycl::queue& queue,
+                               oneapi::math::transpose* trans, std::int64_t* n, std::int64_t* nrhs,
+                               T** a, std::int64_t* lda, std::int64_t** ipiv, T** b,
+                               std::int64_t* ldb, std::int64_t group_count,
+                               std::int64_t* group_sizes, T* scratchpad,
+                               std::int64_t scratchpad_size,
+                               const std::vector<sycl::event>& dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+
+    return queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType**>(a);
+            auto b_ = reinterpret_cast<cuDataType**>(b);
+            cusolverStatus_t err;
+            int64_t global_id = 0;
+            CusolverDnParams params;
+            constexpr cudaDataType data_type = CudaDataType<T>::Type;
+
+            // Does not use scratch so call cuSolver asynchronously and sync at end
+            for (int64_t group_id = 0; group_id < group_count; ++group_id) {
+                for (int64_t local_id = 0; local_id < group_sizes[group_id];
+                     ++local_id, ++global_id) {
+                    CUSOLVER_ERROR_FUNC_T(func_name, cusolverDnXgetrs, err, handle, params.get(),
+                                          get_cublas_operation(trans[group_id]), n[group_id],
+                                          nrhs[group_id], data_type, a_[global_id], lda[group_id],
+                                          ipiv[global_id], data_type, b_[global_id], ldb[group_id],
+                                          nullptr);
+                }
+            }
+#ifndef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+            CUSOLVER_SYNC(err, handle)
+#endif
+        });
+    });
+}
+
+#define GETRS_BATCH_LAUNCHER_USM(TYPE)                                                            \
+    sycl::event getrs_batch(                                                                      \
+        sycl::queue& queue, oneapi::math::transpose* trans, std::int64_t* n, std::int64_t* nrhs,  \
+        TYPE** a, std::int64_t* lda, std::int64_t** ipiv, TYPE** b, std::int64_t* ldb,            \
+        std::int64_t group_count, std::int64_t* group_sizes, TYPE* scratchpad,                    \
+        std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {             \
+        return getrs_batch<TYPE>("cusolverDnXgetrs", queue, trans, n, nrhs, a, lda, ipiv, b, ldb, \
+                                 group_count, group_sizes, scratchpad, scratchpad_size,           \
+                                 dependencies);                                                   \
+    }
+
+GETRS_BATCH_LAUNCHER_USM(float)
+GETRS_BATCH_LAUNCHER_USM(double)
+GETRS_BATCH_LAUNCHER_USM(std::complex<float>)
+GETRS_BATCH_LAUNCHER_USM(std::complex<double>)
+
+#undef GETRS_BATCH_LAUNCHER_USM
+
+#else // no 64-bit pivot API: narrow the pivots into temporary 32-bit arrays
 
 template <typename Func, typename T>
 inline sycl::event getrs_batch(const char* func_name, Func func, sycl::queue& queue,
@@ -1098,6 +1467,8 @@ GETRS_BATCH_LAUNCHER_USM(std::complex<float>, cusolverDnCgetrs)
 GETRS_BATCH_LAUNCHER_USM(std::complex<double>, cusolverDnZgetrs)
 
 #undef GETRS_BATCH_LAUNCHER_USM
+
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
 
 template <typename Func, typename T>
 inline sycl::event orgqr_batch(const char* func_name, Func func, sycl::queue& queue, std::int64_t m,
@@ -1561,6 +1932,46 @@ UNGQR_BATCH_LAUNCHER_USM(std::complex<double>, cusolverDnZungqr)
 
 // BATCH SCRATCHPAD API
 
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+template <typename T>
+inline void getrf_batch_scratchpad_size(const char* func_name, sycl::queue& queue, std::int64_t m,
+                                        std::int64_t n, std::int64_t lda, size_t* device_bytes) {
+    auto e = queue.submit([&](sycl::handler& cgh) {
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            cusolverStatus_t err;
+            CusolverDnParams params;
+            size_t host_bytes;
+            CUSOLVER_ERROR_FUNC_T(func_name, cusolverDnXgetrf_bufferSize, err, handle, params.get(),
+                                  m, n, CudaDataType<T>::Type, nullptr, lda, CudaDataType<T>::Type,
+                                  device_bytes, &host_bytes);
+        });
+    });
+    e.wait();
+}
+
+// cusolverDnXgetrf sizes its device workspace in bytes, oneMath in elements of T.
+#define GETRF_STRIDED_BATCH_LAUNCHER_SCRATCH(TYPE)                                         \
+    template <>                                                                            \
+    std::int64_t getrf_batch_scratchpad_size<TYPE>(                                        \
+        sycl::queue & queue, std::int64_t m, std::int64_t n, std::int64_t lda,             \
+        std::int64_t stride_a, std::int64_t stride_ipiv, std::int64_t batch_size) {        \
+        size_t device_bytes;                                                               \
+        getrf_batch_scratchpad_size<TYPE>("cusolverDnXgetrf_bufferSize", queue, m, n, lda, \
+                                          &device_bytes);                                  \
+        return (device_bytes + sizeof(TYPE) - 1) / sizeof(TYPE);                           \
+    }
+
+GETRF_STRIDED_BATCH_LAUNCHER_SCRATCH(float)
+GETRF_STRIDED_BATCH_LAUNCHER_SCRATCH(double)
+GETRF_STRIDED_BATCH_LAUNCHER_SCRATCH(std::complex<float>)
+GETRF_STRIDED_BATCH_LAUNCHER_SCRATCH(std::complex<double>)
+
+#undef GETRF_STRIDED_BATCH_LAUNCHER_SCRATCH
+
+#else // no 64-bit pivot API: size the legacy workspace instead
+
 template <typename Func>
 inline void getrf_batch_scratchpad_size(const char* func_name, Func func, sycl::queue& queue,
                                         std::int64_t m, std::int64_t n, std::int64_t lda,
@@ -1595,14 +2006,18 @@ GETRF_STRIDED_BATCH_LAUNCHER_SCRATCH(std::complex<double>, cusolverDnZgetrf_buff
 
 #undef GETRF_STRIDED_BATCH_LAUNCHER_SCRATCH
 
-// Scratch memory needs to be the same size as a
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+// Scratch memory needs to be the same size as a, plus a tail holding the 32-bit pivots that
+// cublas<t>getriBatched requires
 #define GETRI_STRIDED_BATCH_LAUNCHER_SCRATCH(TYPE)                                    \
     template <>                                                                       \
     std::int64_t getri_batch_scratchpad_size<TYPE>(                                   \
         sycl::queue & queue, std::int64_t n, std::int64_t lda, std::int64_t stride_a, \
         std::int64_t stride_ipiv, std::int64_t batch_size) {                          \
         assert(stride_a >= lda * n && "A matrices must not overlap");                 \
-        return stride_a * (batch_size - 1) + lda * n;                                 \
+        return stride_a * (batch_size - 1) + lda * n +                                \
+               pivot32_scratchpad_size<TYPE>(n * batch_size);                         \
     }
 
 GETRI_STRIDED_BATCH_LAUNCHER_SCRATCH(float)
@@ -1764,6 +2179,55 @@ ORGQR_STRIDED_BATCH_LAUNCHER_SCRATCH(std::complex<double>, cusolverDnZungqr_buff
 
 #undef ORGQR_STRIDED_BATCH_LAUNCHER_SCRATCH
 
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+template <typename T>
+inline void getrf_batch_scratchpad_size(const char* func_name, sycl::queue& queue, std::int64_t* m,
+                                        std::int64_t* n, std::int64_t* lda,
+                                        std::int64_t group_count, size_t* device_bytes) {
+    auto e = queue.submit([&](sycl::handler& cgh) {
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            size_t group_device_bytes = 0, host_bytes = 0;
+            *device_bytes = 0;
+            cusolverStatus_t err;
+            CusolverDnParams params;
+
+            // Get the maximum scratch_size across the groups
+            for (int64_t group_id = 0; group_id < group_count; ++group_id) {
+                CUSOLVER_ERROR_FUNC_T(func_name, cusolverDnXgetrf_bufferSize, err, handle,
+                                      params.get(), m[group_id], n[group_id], CudaDataType<T>::Type,
+                                      nullptr, lda[group_id], CudaDataType<T>::Type,
+                                      &group_device_bytes, &host_bytes);
+                *device_bytes =
+                    group_device_bytes > *device_bytes ? group_device_bytes : *device_bytes;
+            }
+        });
+    });
+    e.wait();
+}
+
+// cusolverDnXgetrf sizes its device workspace in bytes, oneMath in elements of T.
+#define GETRF_GROUP_LAUNCHER_SCRATCH(TYPE)                                                 \
+    template <>                                                                            \
+    std::int64_t getrf_batch_scratchpad_size<TYPE>(                                        \
+        sycl::queue & queue, std::int64_t* m, std::int64_t* n, std::int64_t* lda,          \
+        std::int64_t group_count, std::int64_t* group_sizes) {                             \
+        size_t device_bytes;                                                               \
+        getrf_batch_scratchpad_size<TYPE>("cusolverDnXgetrf_bufferSize", queue, m, n, lda, \
+                                          group_count, &device_bytes);                     \
+        return (device_bytes + sizeof(TYPE) - 1) / sizeof(TYPE);                           \
+    }
+
+GETRF_GROUP_LAUNCHER_SCRATCH(float)
+GETRF_GROUP_LAUNCHER_SCRATCH(double)
+GETRF_GROUP_LAUNCHER_SCRATCH(std::complex<float>)
+GETRF_GROUP_LAUNCHER_SCRATCH(std::complex<double>)
+
+#undef GETRF_GROUP_LAUNCHER_SCRATCH
+
+#else // no 64-bit pivot API: size the legacy workspace instead
+
 template <typename Func>
 inline void getrf_batch_scratchpad_size(const char* func_name, Func func, sycl::queue& queue,
                                         std::int64_t* m, std::int64_t* n, std::int64_t* lda,
@@ -1806,6 +2270,9 @@ GETRF_GROUP_LAUNCHER_SCRATCH(std::complex<double>, cusolverDnZgetrf_bufferSize)
 
 #undef GETRF_GROUP_LAUNCHER_SCRATCH
 
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+// The tail holds the 32-bit pivots that cublas<t>getriBatched requires
 #define GETRI_GROUP_LAUNCHER_SCRATCH(TYPE)                                                      \
     template <>                                                                                 \
     std::int64_t getri_batch_scratchpad_size<TYPE>(sycl::queue & queue, std::int64_t* n,        \
@@ -1813,7 +2280,8 @@ GETRF_GROUP_LAUNCHER_SCRATCH(std::complex<double>, cusolverDnZgetrf_bufferSize)
                                                    std::int64_t* group_sizes) {                 \
         std::int64_t max_scratch_sz = 0;                                                        \
         for (auto group_id = 0; group_id < group_count; ++group_id) {                           \
-            auto scratch_sz = lda[group_id] * n[group_id];                                      \
+            auto scratch_sz =                                                                   \
+                lda[group_id] * n[group_id] + pivot32_scratchpad_size<TYPE>(n[group_id]);       \
             if (scratch_sz > max_scratch_sz)                                                    \
                 max_scratch_sz = scratch_sz;                                                    \
         }                                                                                       \

--- a/src/lapack/backends/cusolver/cusolver_helper.hpp
+++ b/src/lapack/backends/cusolver/cusolver_helper.hpp
@@ -32,6 +32,8 @@
 #include <cusolverDn.h>
 #include <cuda.h>
 #include <complex>
+#include <cstdint>
+#include <vector>
 
 #include "oneapi/math/types.hpp"
 #include "runtime_support_helper.hpp"
@@ -287,6 +289,162 @@ template <>
 struct CudaEquivalentType<std::complex<double>> {
     using Type = cuDoubleComplex;
 };
+
+/*converting T to the cudaDataType tag expected by the cuSOLVER 64-bit API*/
+template <typename T>
+struct CudaDataType;
+template <>
+struct CudaDataType<float> {
+    static constexpr cudaDataType Type = CUDA_R_32F;
+};
+template <>
+struct CudaDataType<double> {
+    static constexpr cudaDataType Type = CUDA_R_64F;
+};
+template <>
+struct CudaDataType<std::complex<float>> {
+    static constexpr cudaDataType Type = CUDA_C_32F;
+};
+template <>
+struct CudaDataType<std::complex<double>> {
+    static constexpr cudaDataType Type = CUDA_C_64F;
+};
+
+/* 64-bit pivot API */
+
+#if !defined(CUSOLVER_VERSION)
+#define ONEMATH_CUSOLVER_VERSION 0
+#else
+#define ONEMATH_CUSOLVER_VERSION CUSOLVER_VERSION
+#endif
+
+// cuSOLVER exposes getrf/getrs entry points taking int64_t pivots, which lets oneMath
+// hand the user's ipiv array straight through instead of converting it. They first
+// appeared in CUDA 11.0 (CUSOLVER_VERSION 10600) as cusolverDnGetrf/cusolverDnGetrs and
+// were renamed with an X prefix in CUDA 11.1 (11000); the old names are deprecated from
+// 11.1 and removed in CUDA 12. CUDA 10.x has no 64-bit pivot API at all.
+#define ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS (ONEMATH_CUSOLVER_VERSION >= 10600)
+#define ONEMATH_CUSOLVER_HAS_X_NAMES      (ONEMATH_CUSOLVER_VERSION >= 11000)
+
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+#if !ONEMATH_CUSOLVER_HAS_X_NAMES
+// CUDA 11.0 spelling. The pre-X getrf has no host workspace, so the wrapper reports a
+// host requirement of zero and drops the host buffer arguments.
+inline cusolverStatus_t cusolverDnXgetrf_bufferSize(cusolverDnHandle_t handle,
+                                                    cusolverDnParams_t params, int64_t m, int64_t n,
+                                                    cudaDataType dataTypeA, const void* A,
+                                                    int64_t lda, cudaDataType computeType,
+                                                    size_t* workspaceInBytesOnDevice,
+                                                    size_t* workspaceInBytesOnHost) {
+    *workspaceInBytesOnHost = 0;
+    return cusolverDnGetrf_bufferSize(handle, params, m, n, dataTypeA, A, lda, computeType,
+                                      workspaceInBytesOnDevice);
+}
+
+inline cusolverStatus_t cusolverDnXgetrf(cusolverDnHandle_t handle, cusolverDnParams_t params,
+                                         int64_t m, int64_t n, cudaDataType dataTypeA, void* A,
+                                         int64_t lda, int64_t* ipiv, cudaDataType computeType,
+                                         void* bufferOnDevice, size_t workspaceInBytesOnDevice,
+                                         void* bufferOnHost, size_t workspaceInBytesOnHost,
+                                         int* info) {
+    return cusolverDnGetrf(handle, params, m, n, dataTypeA, A, lda, ipiv, computeType,
+                           bufferOnDevice, workspaceInBytesOnDevice, info);
+}
+
+inline cusolverStatus_t cusolverDnXgetrs(cusolverDnHandle_t handle, cusolverDnParams_t params,
+                                         cublasOperation_t trans, int64_t n, int64_t nrhs,
+                                         cudaDataType dataTypeA, const void* A, int64_t lda,
+                                         const int64_t* ipiv, cudaDataType dataTypeB, void* B,
+                                         int64_t ldb, int* info) {
+    return cusolverDnGetrs(handle, params, trans, n, nrhs, dataTypeA, A, lda, ipiv, dataTypeB, B,
+                           ldb, info);
+}
+#endif // !ONEMATH_CUSOLVER_HAS_X_NAMES
+
+// Owns a cusolverDnParams_t for the duration of one call. Caching it across calls is a
+// possible follow-up, tracked together with the handle churn described in issue #298.
+class CusolverDnParams {
+public:
+    CusolverDnParams() {
+        cusolverStatus_t err;
+        CUSOLVER_ERROR_FUNC(cusolverDnCreateParams, err, &params_);
+    }
+    ~CusolverDnParams() {
+        cusolverDnDestroyParams(params_);
+    }
+    CusolverDnParams(const CusolverDnParams&) = delete;
+    CusolverDnParams& operator=(const CusolverDnParams&) = delete;
+
+    cusolverDnParams_t get() const {
+        return params_;
+    }
+
+private:
+    cusolverDnParams_t params_;
+};
+
+// Queries the workspace cusolverDnXgetrf needs for an m-by-n factorisation. The device part
+// is served by the oneMath scratchpad; the host part has no oneMath counterpart and is
+// reported separately so that call sites can provide it.
+template <typename T>
+inline void cusolver_xgetrf_buffer_size(cusolverDnHandle_t handle, cusolverDnParams_t params,
+                                        std::int64_t m, std::int64_t n, std::int64_t lda,
+                                        size_t* device_bytes, size_t* host_bytes) {
+    constexpr cudaDataType data_type = CudaDataType<T>::Type;
+    cusolverStatus_t err;
+    CUSOLVER_ERROR_FUNC(cusolverDnXgetrf_bufferSize, err, handle, params, m, n, data_type, nullptr,
+                        lda, data_type, device_bytes, host_bytes);
+}
+
+// Runs cusolverDnXgetrf with `device_workspace` (of `device_bytes` bytes) as the device
+// workspace. A non-zero host requirement is allocated here and the stream is synchronised
+// before the allocation goes out of scope, since oneMath has no host scratchpad to hold it.
+template <typename T>
+inline void cusolver_xgetrf(const char* func_name, cusolverDnHandle_t handle,
+                            cusolverDnParams_t params, std::int64_t m, std::int64_t n, void* a,
+                            std::int64_t lda, std::int64_t* ipiv, void* device_workspace,
+                            size_t device_bytes, size_t host_bytes, int* devinfo) {
+    constexpr cudaDataType data_type = CudaDataType<T>::Type;
+    cusolverStatus_t err;
+
+    if (host_bytes > 0) {
+        std::vector<char> host_workspace(host_bytes);
+        CUSOLVER_ERROR_FUNC_T_SYNC(func_name, cusolverDnXgetrf, err, handle, params, m, n,
+                                   data_type, a, lda, ipiv, data_type, device_workspace,
+                                   device_bytes, host_workspace.data(), host_bytes, devinfo)
+    }
+    else {
+        cusolver_native_named_func(func_name, cusolverDnXgetrf, err, handle, params, m, n,
+                                   data_type, a, lda, ipiv, data_type, device_workspace,
+                                   device_bytes, nullptr, size_t{ 0 }, devinfo);
+    }
+}
+
+// Runs cusolverDnXgetrs. It takes no workspace at all, so nothing else is needed here.
+template <typename T>
+inline void cusolver_xgetrs(const char* func_name, cusolverDnHandle_t handle,
+                            cusolverDnParams_t params, cublasOperation_t trans, std::int64_t n,
+                            std::int64_t nrhs, const void* a, std::int64_t lda,
+                            const std::int64_t* ipiv, void* b, std::int64_t ldb) {
+    constexpr cudaDataType data_type = CudaDataType<T>::Type;
+    cusolverStatus_t err;
+    cusolver_native_named_func(func_name, cusolverDnXgetrs, err, handle, params, trans, n, nrhs,
+                               data_type, a, lda, ipiv, data_type, b, ldb, nullptr);
+}
+
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+// Number of T elements needed to store `count` 32-bit pivots. cuSOLVER's sytrf and cuBLAS'
+// getriBatched have no 64-bit pivot counterpart, so their pivot array is carved out of the
+// tail of the oneMath scratchpad rather than allocated separately. That removes the separate
+// allocation and the host synchronisation its release would otherwise need; routines that
+// also report info still synchronise in lapack_info_check. sizeof(T) is a multiple of 4 for
+// every supported type, so an offset expressed in T elements is always suitably aligned for int.
+template <typename T>
+inline std::int64_t pivot32_scratchpad_size(std::int64_t count) {
+    return (count * static_cast<std::int64_t>(sizeof(int)) + sizeof(T) - 1) / sizeof(T);
+}
 
 /* devinfo */
 

--- a/src/lapack/backends/cusolver/cusolver_helper.hpp
+++ b/src/lapack/backends/cusolver/cusolver_helper.hpp
@@ -300,7 +300,9 @@ inline void get_cusolver_devinfo(sycl::queue& queue, sycl::buffer<int>& devInfo,
 inline void get_cusolver_devinfo(sycl::queue& queue, const int* devInfo,
                                  std::vector<int>& dev_info_) {
     queue.wait();
-    queue.memcpy(dev_info_.data(), devInfo, sizeof(int));
+    // The copy must complete before dev_info_ is read: callers inspect it as soon as this
+    // returns and then release devInfo, both of which race with an outstanding copy.
+    queue.memcpy(dev_info_.data(), devInfo, sizeof(int) * dev_info_.size()).wait();
 }
 
 template <typename DEVINFO_T>

--- a/src/lapack/backends/cusolver/cusolver_lapack.cpp
+++ b/src/lapack/backends/cusolver/cusolver_lapack.cpp
@@ -138,6 +138,53 @@ GEQRF_LAUNCHER(std::complex<double>, cusolverDnZgeqrf)
 
 #undef GEQRF_LAUNCHER
 
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+template <typename T>
+void getrf(const char* func_name, sycl::queue& queue, std::int64_t m, std::int64_t n,
+           sycl::buffer<T>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
+           sycl::buffer<T>& scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+    sycl::buffer<int> devInfo{ 1 };
+
+    queue.submit([&](sycl::handler& cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto ipiv_acc = ipiv.template get_access<sycl::access::mode::write>(cgh);
+        auto devInfo_acc = devInfo.template get_access<sycl::access::mode::write>(cgh);
+        auto scratch_acc = scratchpad.template get_access<sycl::access::mode::write>(cgh);
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType*>(a_acc);
+            auto ipiv_ = sc.get_mem<std::int64_t*>(ipiv_acc);
+            auto devInfo_ = sc.get_mem<int*>(devInfo_acc);
+            auto scratch_ = sc.get_mem<cuDataType*>(scratch_acc);
+            CusolverDnParams params;
+            size_t device_bytes, host_bytes;
+            cusolver_xgetrf_buffer_size<T>(handle, params.get(), m, n, lda, &device_bytes,
+                                           &host_bytes);
+            cusolver_xgetrf<T>(func_name, handle, params.get(), m, n, a_, lda, ipiv_, scratch_,
+                               scratchpad_size * sizeof(T), host_bytes, devInfo_);
+        });
+    });
+    lapack_info_check(queue, devInfo, __func__, func_name);
+}
+
+#define GETRF_LAUNCHER(TYPE)                                                                       \
+    void getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<TYPE>& a,          \
+               std::int64_t lda, sycl::buffer<std::int64_t>& ipiv, sycl::buffer<TYPE>& scratchpad, \
+               std::int64_t scratchpad_size) {                                                     \
+        getrf<TYPE>("cusolverDnXgetrf", queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size);   \
+    }
+
+GETRF_LAUNCHER(float)
+GETRF_LAUNCHER(double)
+GETRF_LAUNCHER(std::complex<float>)
+GETRF_LAUNCHER(std::complex<double>)
+
+#undef GETRF_LAUNCHER
+
+#else // no 64-bit pivot API: factorise into a temporary 32-bit array and widen it
+
 template <typename Func, typename T>
 void getrf(const char* func_name, Func func, sycl::queue& queue, std::int64_t m, std::int64_t n,
            sycl::buffer<T>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
@@ -195,6 +242,8 @@ GETRF_LAUNCHER(std::complex<double>, cusolverDnZgetrf)
 
 #undef GETRF_LAUNCHER
 
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
 #define GETRI_LAUNCHER(TYPE)                                                                    \
     void getri(sycl::queue& queue, std::int64_t n, sycl::buffer<TYPE>& a, std::int64_t lda,     \
                sycl::buffer<std::int64_t>& ipiv, sycl::buffer<TYPE>& scratchpad,                \
@@ -209,7 +258,51 @@ GETRI_LAUNCHER(std::complex<double>)
 
 #undef GETRI_LAUNCHER
 
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
 // cusolverDnXgetrs does not use scratchpad memory
+template <typename T>
+inline void getrs(const char* func_name, sycl::queue& queue, oneapi::math::transpose trans,
+                  std::int64_t n, std::int64_t nrhs, sycl::buffer<T>& a, std::int64_t lda,
+                  sycl::buffer<std::int64_t>& ipiv, sycl::buffer<T>& b, std::int64_t ldb,
+                  sycl::buffer<T>& scratchpad, std::int64_t scratchpad_size) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+
+    queue.submit([&](sycl::handler& cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto ipiv_acc = ipiv.template get_access<sycl::access::mode::read>(cgh);
+        auto b_acc = b.template get_access<sycl::access::mode::write>(cgh);
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<cuDataType*>(a_acc);
+            auto ipiv_ = sc.get_mem<std::int64_t*>(ipiv_acc);
+            auto b_ = sc.get_mem<cuDataType*>(b_acc);
+            CusolverDnParams params;
+            cusolver_xgetrs<T>(func_name, handle, params.get(), get_cublas_operation(trans), n,
+                               nrhs, a_, lda, ipiv_, b_, ldb);
+        });
+    });
+}
+
+#define GETRS_LAUNCHER(TYPE)                                                                     \
+    void getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n,                \
+               std::int64_t nrhs, sycl::buffer<TYPE>& a, std::int64_t lda,                       \
+               sycl::buffer<std::int64_t>& ipiv, sycl::buffer<TYPE>& b, std::int64_t ldb,        \
+               sycl::buffer<TYPE>& scratchpad, std::int64_t scratchpad_size) {                   \
+        getrs<TYPE>("cusolverDnXgetrs", queue, trans, n, nrhs, a, lda, ipiv, b, ldb, scratchpad, \
+                    scratchpad_size);                                                            \
+    }
+
+GETRS_LAUNCHER(float)
+GETRS_LAUNCHER(double)
+GETRS_LAUNCHER(std::complex<float>)
+GETRS_LAUNCHER(std::complex<double>)
+
+#undef GETRS_LAUNCHER
+
+#else // no 64-bit pivot API: narrow the pivots into a temporary 32-bit array
+
+// cusolverDn<t>getrs does not use scratchpad memory
 template <typename Func, typename T>
 inline void getrs(const char* func_name, Func func, sycl::queue& queue,
                   oneapi::math::transpose trans, std::int64_t n, std::int64_t nrhs,
@@ -264,6 +357,8 @@ GETRS_LAUNCHER(std::complex<float>, cusolverDnCgetrs)
 GETRS_LAUNCHER(std::complex<double>, cusolverDnZgetrs)
 
 #undef GETRS_LAUNCHER
+
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
 
 template <typename Func, typename T_A, typename T_B>
 inline void gesvd(const char* func_name, Func func, sycl::queue& queue, oneapi::math::jobsvd jobu,
@@ -916,10 +1011,11 @@ inline void sytrf(const char* func_name, Func func, sycl::queue& queue, oneapi::
     overflow_check(n, lda, scratchpad_size);
     sycl::buffer<int> devInfo{ 1 };
 
-    // cuSolver legacy api does not accept 64-bit ints.
-    // To get around the limitation.
-    // Create new buffer with 32-bit ints then copy over results
+    // cuSolver has no 64-bit pivot variant of sytrf, so a 32-bit array is unavoidable.
+    // The tail of the scratchpad is reserved for it (see sytrf_scratchpad_size); the buffer
+    // API can afford a separate temporary instead, as the SYCL runtime tracks the dependency.
     std::uint64_t ipiv_size = n;
+    std::int64_t cusolver_scratchpad_size = scratchpad_size - pivot32_scratchpad_size<T>(n);
     sycl::buffer<int, 1> ipiv32(sycl::range<1>{ ipiv_size });
 
     queue.submit([&](sycl::handler& cgh) {
@@ -935,7 +1031,8 @@ inline void sytrf(const char* func_name, Func func, sycl::queue& queue, oneapi::
             auto scratch_ = sc.get_mem<cuDataType*>(scratch_acc);
             cusolverStatus_t err;
             cusolver_native_named_func(func_name, func, err, handle, get_cublas_fill_mode(uplo), n,
-                                       a_, lda, ipiv32_, scratch_, scratchpad_size, devInfo_);
+                                       a_, lda, ipiv32_, scratch_, cusolver_scratchpad_size,
+                                       devInfo_);
         });
     });
 
@@ -1308,6 +1405,55 @@ GEQRF_LAUNCHER_USM(std::complex<double>, cusolverDnZgeqrf)
 
 #undef GEQRF_LAUNCHER_USM
 
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+template <typename T>
+inline sycl::event getrf(const char* func_name, sycl::queue& queue, std::int64_t m, std::int64_t n,
+                         T* a, std::int64_t lda, std::int64_t* ipiv, T* scratchpad,
+                         std::int64_t scratchpad_size,
+                         const std::vector<sycl::event>& dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+
+    int* devInfo = (int*)malloc_device(sizeof(int), queue);
+    auto done = queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType*>(a);
+            auto scratch_ = reinterpret_cast<cuDataType*>(scratchpad);
+            CusolverDnParams params;
+            size_t device_bytes, host_bytes;
+            cusolver_xgetrf_buffer_size<T>(handle, params.get(), m, n, lda, &device_bytes,
+                                           &host_bytes);
+            cusolver_xgetrf<T>(func_name, handle, params.get(), m, n, a_, lda, ipiv, scratch_,
+                               scratchpad_size * sizeof(T), host_bytes, devInfo);
+        });
+    });
+
+    // lapack_info_check calls queue.wait()
+    lapack_info_check(queue, devInfo, __func__, func_name);
+    free(devInfo, queue);
+    return done;
+}
+
+#define GETRF_LAUNCHER_USM(TYPE)                                                      \
+    sycl::event getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, TYPE* a,    \
+                      std::int64_t lda, std::int64_t* ipiv, TYPE* scratchpad,         \
+                      std::int64_t scratchpad_size,                                   \
+                      const std::vector<sycl::event>& dependencies) {                 \
+        return getrf<TYPE>("cusolverDnXgetrf", queue, m, n, a, lda, ipiv, scratchpad, \
+                           scratchpad_size, dependencies);                            \
+    }
+
+GETRF_LAUNCHER_USM(float)
+GETRF_LAUNCHER_USM(double)
+GETRF_LAUNCHER_USM(std::complex<float>)
+GETRF_LAUNCHER_USM(std::complex<double>)
+
+#undef GETRF_LAUNCHER_USM
+
+#else // no 64-bit pivot API: factorise into a temporary 32-bit array and widen it
+
 template <typename Func, typename T>
 inline sycl::event getrf(const char* func_name, Func func, sycl::queue& queue, std::int64_t m,
                          std::int64_t n, T* a, std::int64_t lda, std::int64_t* ipiv, T* scratchpad,
@@ -1373,6 +1519,8 @@ GETRF_LAUNCHER_USM(std::complex<double>, cusolverDnZgetrf)
 
 #undef GETRF_LAUNCHER_USM
 
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
 #define GETRI_LAUNCHER_USM(TYPE)                                                               \
     sycl::event getri(sycl::queue& queue, std::int64_t n, TYPE* a, std::int64_t lda,           \
                       std::int64_t* ipiv, TYPE* scratchpad, std::int64_t scratchpad_size,      \
@@ -1388,7 +1536,49 @@ GETRI_LAUNCHER_USM(std::complex<double>)
 
 #undef GETRI_LAUNCHER_USM
 
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
 // cusolverDnXgetrs does not use scratchpad memory
+template <typename T>
+inline sycl::event getrs(const char* func_name, sycl::queue& queue, oneapi::math::transpose trans,
+                         std::int64_t n, std::int64_t nrhs, T* a, std::int64_t lda,
+                         std::int64_t* ipiv, T* b, std::int64_t ldb, T* scratchpad,
+                         std::int64_t scratchpad_size,
+                         const std::vector<sycl::event>& dependencies) {
+    using cuDataType = typename CudaEquivalentType<T>::Type;
+
+    return queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+        onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<cuDataType*>(a);
+            auto b_ = reinterpret_cast<cuDataType*>(b);
+            CusolverDnParams params;
+            cusolver_xgetrs<T>(func_name, handle, params.get(), get_cublas_operation(trans), n,
+                               nrhs, a_, lda, ipiv, b_, ldb);
+        });
+    });
+}
+
+#define GETRS_LAUNCHER_USM(TYPE)                                                                 \
+    sycl::event getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n,         \
+                      std::int64_t nrhs, TYPE* a, std::int64_t lda, std::int64_t* ipiv, TYPE* b, \
+                      std::int64_t ldb, TYPE* scratchpad, std::int64_t scratchpad_size,          \
+                      const std::vector<sycl::event>& dependencies) {                            \
+        return getrs<TYPE>("cusolverDnXgetrs", queue, trans, n, nrhs, a, lda, ipiv, b, ldb,      \
+                           scratchpad, scratchpad_size, dependencies);                           \
+    }
+
+GETRS_LAUNCHER_USM(float)
+GETRS_LAUNCHER_USM(double)
+GETRS_LAUNCHER_USM(std::complex<float>)
+GETRS_LAUNCHER_USM(std::complex<double>)
+
+#undef GETRS_LAUNCHER_USM
+
+#else // no 64-bit pivot API: narrow the pivots into a temporary 32-bit array
+
+// cusolverDn<t>getrs does not use scratchpad memory
 template <typename Func, typename T>
 inline sycl::event getrs(const char* func_name, Func func, sycl::queue& queue,
                          oneapi::math::transpose trans, std::int64_t n, std::int64_t nrhs, T* a,
@@ -1449,6 +1639,8 @@ GETRS_LAUNCHER_USM(std::complex<float>, cusolverDnCgetrs)
 GETRS_LAUNCHER_USM(std::complex<double>, cusolverDnZgetrs)
 
 #undef GETRS_LAUNCHER_USM
+
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
 
 template <typename Func, typename T_A, typename T_B>
 inline sycl::event gesvd(const char* func_name, Func func, sycl::queue& queue,
@@ -2143,11 +2335,13 @@ inline sycl::event sytrf(const char* func_name, Func func, sycl::queue& queue,
     overflow_check(n, lda, scratchpad_size);
     int* devInfo = (int*)malloc_device(sizeof(int), queue);
 
-    // cuSolver legacy api does not accept 64-bit ints.
-    // To get around the limitation.
-    // Allocate memory with 32-bit ints then copy over results
+    // cuSolver has no 64-bit pivot variant of sytrf, so a 32-bit array is unavoidable. It is
+    // carved out of the tail of the scratchpad (see sytrf_scratchpad_size), which avoids both
+    // a separate allocation and the host synchronisation that releasing it would require.
+    // This routine still blocks in lapack_info_check below.
     std::uint64_t ipiv_size = n;
-    int* ipiv32 = (int*)malloc_device(sizeof(int) * ipiv_size, queue);
+    std::int64_t cusolver_scratchpad_size = scratchpad_size - pivot32_scratchpad_size<T>(n);
+    int* ipiv32 = reinterpret_cast<int*>(scratchpad + cusolver_scratchpad_size);
 
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
@@ -2162,7 +2356,8 @@ inline sycl::event sytrf(const char* func_name, Func func, sycl::queue& queue,
             auto devInfo_ = reinterpret_cast<int*>(devInfo);
             cusolverStatus_t err;
             cusolver_native_named_func(func_name, func, err, handle, get_cublas_fill_mode(uplo), n,
-                                       a_, lda, ipiv_, scratch_, scratchpad_size, devInfo_);
+                                       a_, lda, ipiv_, scratch_, cusolver_scratchpad_size,
+                                       devInfo_);
         });
     });
 
@@ -2173,10 +2368,6 @@ inline sycl::event sytrf(const char* func_name, Func func, sycl::queue& queue,
             ipiv[index] = static_cast<std::int64_t>(ipiv32[index]);
         });
     });
-
-    queue.wait();
-
-    free(ipiv32, queue);
 
     lapack_info_check(queue, devInfo, __func__, func_name);
     free(devInfo, queue);
@@ -2567,6 +2758,46 @@ GESVD_LAUNCHER_SCRATCH(std::complex<double>, cusolverDnZgesvd_bufferSize)
 
 #undef GESVD_LAUNCHER_SCRATCH
 
+#if ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+template <typename T>
+inline void getrf_scratchpad_size(const char* func_name, sycl::queue& queue, std::int64_t m,
+                                  std::int64_t n, std::int64_t lda, size_t* device_bytes) {
+    queue
+        .submit([&](sycl::handler& cgh) {
+            onemath_cusolver_host_task(cgh, queue, [=](CusolverScopedContextHandler& sc) {
+                auto handle = sc.get_handle(queue);
+                cusolverStatus_t err;
+                CusolverDnParams params;
+                size_t host_bytes;
+                CUSOLVER_ERROR_FUNC_T_SYNC(func_name, cusolverDnXgetrf_bufferSize, err, handle,
+                                           params.get(), m, n, CudaDataType<T>::Type, nullptr, lda,
+                                           CudaDataType<T>::Type, device_bytes, &host_bytes);
+            });
+        })
+        .wait();
+}
+
+// cusolverDnXgetrf sizes its device workspace in bytes, oneMath in elements of T.
+#define GETRF_LAUNCHER_SCRATCH(TYPE)                                                              \
+    template <>                                                                                   \
+    std::int64_t getrf_scratchpad_size<TYPE>(sycl::queue & queue, std::int64_t m, std::int64_t n, \
+                                             std::int64_t lda) {                                  \
+        size_t device_bytes;                                                                      \
+        getrf_scratchpad_size<TYPE>("cusolverDnXgetrf_bufferSize", queue, m, n, lda,              \
+                                    &device_bytes);                                               \
+        return (device_bytes + sizeof(TYPE) - 1) / sizeof(TYPE);                                  \
+    }
+
+GETRF_LAUNCHER_SCRATCH(float)
+GETRF_LAUNCHER_SCRATCH(double)
+GETRF_LAUNCHER_SCRATCH(std::complex<float>)
+GETRF_LAUNCHER_SCRATCH(std::complex<double>)
+
+#undef GETRF_LAUNCHER_SCRATCH
+
+#else // no 64-bit pivot API: size the legacy workspace instead
+
 template <typename Func>
 inline void getrf_scratchpad_size(const char* func_name, Func func, sycl::queue& queue,
                                   std::int64_t m, std::int64_t n, std::int64_t lda,
@@ -2600,11 +2831,14 @@ GETRF_LAUNCHER_SCRATCH(std::complex<double>, cusolverDnZgetrf_bufferSize)
 
 #undef GETRF_LAUNCHER_SCRATCH
 
+#endif // ONEMATH_CUSOLVER_HAS_64BIT_PIVOTS
+
+// The tail holds the 32-bit pivots that cublas<t>getriBatched requires
 #define GETRI_LAUNCHER_SCRATCH(TYPE)                                              \
     template <>                                                                   \
     std::int64_t getri_scratchpad_size<TYPE>(sycl::queue & queue, std::int64_t n, \
                                              std::int64_t lda) {                  \
-        return lda * n;                                                           \
+        return lda * n + pivot32_scratchpad_size<TYPE>(n);                        \
     }
 
 GETRI_LAUNCHER_SCRATCH(float)
@@ -3017,6 +3251,7 @@ inline void sytrf_scratchpad_size(const char* func_name, Func func, sycl::queue&
         .wait();
 }
 
+// The tail holds the 32-bit pivots that cusolverDn<t>sytrf requires
 #define SYTRF_LAUNCHER_SCRATCH(TYPE, CUSOLVER_ROUTINE)                                     \
     template <>                                                                            \
     std::int64_t sytrf_scratchpad_size<TYPE>(sycl::queue & queue, oneapi::math::uplo uplo, \
@@ -3024,7 +3259,7 @@ inline void sytrf_scratchpad_size(const char* func_name, Func func, sycl::queue&
         int scratch_size;                                                                  \
         sytrf_scratchpad_size(#CUSOLVER_ROUTINE, CUSOLVER_ROUTINE, queue, uplo, n, lda,    \
                               &scratch_size);                                              \
-        return scratch_size;                                                               \
+        return scratch_size + pivot32_scratchpad_size<TYPE>(n);                            \
     }
 
 SYTRF_LAUNCHER_SCRATCH(float, cusolverDnSsytrf_bufferSize)


### PR DESCRIPTION
## Summary

Fixes #230.

oneMath types `ipiv` as `int64_t`, while the legacy cuSOLVER and cuBLAS entry points take `int`. Every affected routine therefore allocated a temporary 32-bit array and ran a cast kernel around the call, and in the USM paths it also forced a `queue.wait()` to release that temporary.

cuSOLVER has accepted `int64_t` pivots since CUDA 11.0, so `getrf`, `getrs` and their batch variants now pass the user's `ipiv` straight through. That removes 10 of the 14 temporary allocations and their cast kernels.

The entry points are named `cusolverDnGetrf`/`cusolverDnGetrs` in CUDA 11.0 and were renamed to `cusolverDnXgetrf`/`cusolverDnXgetrs` in 11.1. Inline wrappers hide that difference, and CUDA 10.x keeps the previous conversion path, so no minimum-toolkit requirement changes.

`sytrf` and `getri_batch` have no 64-bit counterpart. Their pivot array is now carved out of the tail of the scratchpad rather than allocated separately, which removes the blocking wait that releasing it required. The matching `*_scratchpad_size` queries account for the tail, so callers that query the size (as the API requires) are unaffected.

Because the 64-bit API takes the dimensions as `int64_t`, `getrf` and `getrs` no longer need the `overflow_check` that rejected sizes above the 32-bit limit, so these routines now accept dimensions beyond 2^31.

### Scope note

This reduces synchronization but does not make the USM paths fully asynchronous: routines that report `info` still block in `lapack_info_check`, which is pre-existing behaviour shared by the rest of the backend and left for separate work.

### Separate commit

The first commit is an independent bug fix in `get_cusolver_devinfo`, kept separate for review. It issued an asynchronous `memcpy` and returned without waiting, while callers read the host vector immediately and then freed the device buffer, so the copy raced with both a destroyed destination and a released source. The copy was also hard-coded to a single `int` even though batched routines pass `batch_size` as the info count, leaving the remaining entries uninitialised and allowing a spurious `computation_error`. This is latent on `develop`; removing the pivot waits widened the window enough to make it reproducible.

## Test plan

Built against CUDA 13.3.1 with DPC++ and tested on an NVIDIA A100.

- [x] Functional LAPACK tests, both compile-time and run-time dispatch: 328 passed, 0 failed, 70 skipped, matching the `develop` baseline. Covers `getrf`, `getrs`, `getri`, `sytrf` and the `getrf_batch`, `getrs_batch`, `getri_batch` variants for all four types in both buffer and USM forms.
- [x] Repeated full-suite runs (6x compile-time, plus run-time dispatch) to rule out intermittency.
- [x] The devinfo fix was validated against a flaky `Unmtr`/`Ormtr` dependency failure: 2 failures in 60 focused runs before the fix, 0 in 60 after, versus 0 in 60 on the unmodified baseline.
- [x] Version-guarded fallbacks compile-checked against real headers for CUDA 10.2 (cuSOLVER 10.3.0, legacy conversion path), 11.0.3 (10.6.0, non-X names via wrappers), 11.1.1 (11.0.1, X names) and 12.0.1.
- [x] `clang-format` clean against the repository's `_clang-format`.