### PR TITLE
[lapack][rocsolver] Use the 64-bit pivot API for getrf and getrs

### DIFF
--- a/src/lapack/backends/rocsolver/rocsolver_helper.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_helper.hpp
@@ -255,16 +255,33 @@ struct RocmEquivalentType<std::complex<double>> {
     using Type = rocblas_double_complex;
 };
 
+/* 64-bit pivot API */
+
+#if !defined(ROCSOLVER_VERSION_MAJOR)
+#define ONEMATH_ROCSOLVER_VERSION 0
+#else
+#define ONEMATH_ROCSOLVER_VERSION (ROCSOLVER_VERSION_MAJOR * 100 + ROCSOLVER_VERSION_MINOR)
+#endif
+
+// rocSOLVER exposes getrf and getrs entry points taking int64_t pivots, which lets oneMath hand
+// the user's ipiv array straight through instead of converting it. They were added in rocSOLVER
+// 3.26 (ROCm 6.2); earlier versions keep the conversion path, so the minimum supported ROCm is
+// unchanged.
+#define ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS (ONEMATH_ROCSOLVER_VERSION >= 326)
+
 /* devinfo */
 
-inline int get_rocsolver_devinfo(sycl::queue& queue, sycl::buffer<int>& devInfo) {
-    sycl::host_accessor<int, 1, sycl::access::mode::read> dev_info_{ devInfo };
+// The 64-bit entry points report info as int64_t, the legacy ones as int.
+template <typename INFO_T>
+inline INFO_T get_rocsolver_devinfo(sycl::queue& queue, sycl::buffer<INFO_T>& devInfo) {
+    sycl::host_accessor<INFO_T, 1, sycl::access::mode::read> dev_info_{ devInfo };
     return dev_info_[0];
 }
 
-inline int get_rocsolver_devinfo(sycl::queue& queue, const int* devInfo) {
-    int dev_info_;
-    queue.memcpy(&dev_info_, devInfo, sizeof(int));
+template <typename INFO_T>
+inline INFO_T get_rocsolver_devinfo(sycl::queue& queue, const INFO_T* devInfo) {
+    INFO_T dev_info_;
+    queue.memcpy(&dev_info_, devInfo, sizeof(INFO_T));
     queue.wait();
     return dev_info_;
 }
@@ -273,7 +290,7 @@ template <typename DEVINFO_T>
 inline void lapack_info_check(sycl::queue& queue, DEVINFO_T devinfo, const char* func_name,
                               const char* cufunc_name) {
     queue.wait();
-    const int devinfo_ = get_rocsolver_devinfo(queue, devinfo);
+    const auto devinfo_ = get_rocsolver_devinfo(queue, devinfo);
     if (devinfo_ > 0)
         throw oneapi::math::lapack::computation_error(
             func_name, std::string(cufunc_name) + " failed with info = " + std::to_string(devinfo_),

--- a/src/lapack/backends/rocsolver/rocsolver_lapack.cpp
+++ b/src/lapack/backends/rocsolver/rocsolver_lapack.cpp
@@ -132,6 +132,49 @@ GEQRF_LAUNCHER(std::complex<double>, rocsolver_zgeqrf)
 
 #undef GEQRF_LAUNCHER
 
+#if ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS
+
+template <typename Func, typename T>
+void getrf(const char* func_name, Func func, sycl::queue& queue, std::int64_t m, std::int64_t n,
+           sycl::buffer<T>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
+           sycl::buffer<T>& scratchpad, std::int64_t scratchpad_size) {
+    using rocmDataType = typename RocmEquivalentType<T>::Type;
+    sycl::buffer<std::int64_t> devInfo{ 1 };
+
+    queue.submit([&](sycl::handler& cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto ipiv_acc = ipiv.template get_access<sycl::access::mode::write>(cgh);
+        auto devInfo_acc = devInfo.template get_access<sycl::access::mode::write>(cgh);
+        onemath_rocsolver_host_task(cgh, queue, [=](RocsolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<rocmDataType*>(a_acc);
+            auto ipiv_ = sc.get_mem<std::int64_t*>(ipiv_acc);
+            auto devInfo_ = sc.get_mem<std::int64_t*>(devInfo_acc);
+            rocblas_status err;
+            rocsolver_native_named_func(func_name, func, err, handle, m, n, a_, lda, ipiv_,
+                                        devInfo_);
+        });
+    });
+    lapack_info_check(queue, devInfo, __func__, func_name);
+}
+
+#define GETRF_LAUNCHER(TYPE, ROCSOLVER_ROUTINE)                                                    \
+    void getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<TYPE>& a,          \
+               std::int64_t lda, sycl::buffer<std::int64_t>& ipiv, sycl::buffer<TYPE>& scratchpad, \
+               std::int64_t scratchpad_size) {                                                     \
+        getrf(#ROCSOLVER_ROUTINE, ROCSOLVER_ROUTINE, queue, m, n, a, lda, ipiv, scratchpad,        \
+              scratchpad_size);                                                                    \
+    }
+
+GETRF_LAUNCHER(float, rocsolver_sgetrf_64)
+GETRF_LAUNCHER(double, rocsolver_dgetrf_64)
+GETRF_LAUNCHER(std::complex<float>, rocsolver_cgetrf_64)
+GETRF_LAUNCHER(std::complex<double>, rocsolver_zgetrf_64)
+
+#undef GETRF_LAUNCHER
+
+#else // no 64-bit pivot API: factorise into a temporary 32-bit array and widen it
+
 template <typename Func, typename T>
 void getrf(const char* func_name, Func func, sycl::queue& queue, std::int64_t m, std::int64_t n,
            sycl::buffer<T>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
@@ -188,6 +231,8 @@ GETRF_LAUNCHER(std::complex<double>, rocsolver_zgetrf)
 
 #undef GETRF_LAUNCHER
 
+#endif // ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS
+
 void getri(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>>& a,
            std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
@@ -208,6 +253,50 @@ void getri(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
     throw unimplemented("lapack", "getri");
 }
+
+#if ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS
+
+template <typename Func, typename T>
+inline void getrs(const char* func_name, Func func, sycl::queue& queue,
+                  oneapi::math::transpose trans, std::int64_t n, std::int64_t nrhs,
+                  sycl::buffer<T>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
+                  sycl::buffer<T>& b, std::int64_t ldb, sycl::buffer<T>& scratchpad,
+                  std::int64_t scratchpad_size) {
+    using rocmDataType = typename RocmEquivalentType<T>::Type;
+
+    queue.submit([&](sycl::handler& cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto ipiv_acc = ipiv.template get_access<sycl::access::mode::read>(cgh);
+        auto b_acc = b.template get_access<sycl::access::mode::write>(cgh);
+        onemath_rocsolver_host_task(cgh, queue, [=](RocsolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = sc.get_mem<rocmDataType*>(a_acc);
+            auto ipiv_ = sc.get_mem<std::int64_t*>(ipiv_acc);
+            auto b_ = sc.get_mem<rocmDataType*>(b_acc);
+            rocblas_status err;
+            rocsolver_native_named_func(func_name, func, err, handle, get_rocblas_operation(trans),
+                                        n, nrhs, a_, lda, ipiv_, b_, ldb);
+        });
+    });
+}
+
+#define GETRS_LAUNCHER(TYPE, ROCSOLVER_ROUTINE)                                                   \
+    void getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n,                 \
+               std::int64_t nrhs, sycl::buffer<TYPE>& a, std::int64_t lda,                        \
+               sycl::buffer<std::int64_t>& ipiv, sycl::buffer<TYPE>& b, std::int64_t ldb,         \
+               sycl::buffer<TYPE>& scratchpad, std::int64_t scratchpad_size) {                    \
+        getrs(#ROCSOLVER_ROUTINE, ROCSOLVER_ROUTINE, queue, trans, n, nrhs, a, lda, ipiv, b, ldb, \
+              scratchpad, scratchpad_size);                                                       \
+    }
+
+GETRS_LAUNCHER(float, rocsolver_sgetrs_64)
+GETRS_LAUNCHER(double, rocsolver_dgetrs_64)
+GETRS_LAUNCHER(std::complex<float>, rocsolver_cgetrs_64)
+GETRS_LAUNCHER(std::complex<double>, rocsolver_zgetrs_64)
+
+#undef GETRS_LAUNCHER
+
+#else // no 64-bit pivot API: narrow the pivots into a temporary 32-bit array
 
 template <typename Func, typename T>
 inline void getrs(const char* func_name, Func func, sycl::queue& queue,
@@ -263,6 +352,8 @@ GETRS_LAUNCHER(std::complex<float>, rocsolver_cgetrs)
 GETRS_LAUNCHER(std::complex<double>, rocsolver_zgetrs)
 
 #undef GETRS_LAUNCHER
+
+#endif // ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS
 
 template <typename Func, typename T_A, typename T_B>
 inline void gesvd(const char* func_name, Func func, sycl::queue& queue, oneapi::math::jobsvd jobu,
@@ -1259,6 +1350,50 @@ GEQRF_LAUNCHER_USM(std::complex<double>, rocsolver_zgeqrf)
 
 #undef GEQRF_LAUNCHER_USM
 
+#if ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS
+
+template <typename Func, typename T>
+inline sycl::event getrf(const char* func_name, Func func, sycl::queue& queue, std::int64_t m,
+                         std::int64_t n, T* a, std::int64_t lda, std::int64_t* ipiv, T* scratchpad,
+                         std::int64_t scratchpad_size,
+                         const std::vector<sycl::event>& dependencies) {
+    using rocmDataType = typename RocmEquivalentType<T>::Type;
+
+    std::int64_t* devInfo = (std::int64_t*)malloc_device(sizeof(std::int64_t), queue);
+    auto done = queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+        onemath_rocsolver_host_task(cgh, queue, [=](RocsolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<rocmDataType*>(a);
+            rocblas_status err;
+            rocsolver_native_named_func(func_name, func, err, handle, m, n, a_, lda, ipiv, devInfo);
+        });
+    });
+
+    // lapack_info_check calls queue.wait()
+    lapack_info_check(queue, devInfo, __func__, func_name);
+    free(devInfo, queue);
+    return done;
+}
+
+#define GETRF_LAUNCHER_USM(TYPE, ROCSOLVER_ROUTINE)                                                \
+    sycl::event getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, TYPE* a,                 \
+                      std::int64_t lda, std::int64_t* ipiv, TYPE* scratchpad,                      \
+                      std::int64_t scratchpad_size,                                                \
+                      const std::vector<sycl::event>& dependencies) {                              \
+        return getrf(#ROCSOLVER_ROUTINE, ROCSOLVER_ROUTINE, queue, m, n, a, lda, ipiv, scratchpad, \
+                     scratchpad_size, dependencies);                                               \
+    }
+
+GETRF_LAUNCHER_USM(float, rocsolver_sgetrf_64)
+GETRF_LAUNCHER_USM(double, rocsolver_dgetrf_64)
+GETRF_LAUNCHER_USM(std::complex<float>, rocsolver_cgetrf_64)
+GETRF_LAUNCHER_USM(std::complex<double>, rocsolver_zgetrf_64)
+
+#undef GETRF_LAUNCHER_USM
+
+#else // no 64-bit pivot API: factorise into a temporary 32-bit array and widen it
+
 template <typename Func, typename T>
 inline sycl::event getrf(const char* func_name, Func func, sycl::queue& queue, std::int64_t m,
                          std::int64_t n, T* a, std::int64_t lda, std::int64_t* ipiv, T* scratchpad,
@@ -1320,6 +1455,8 @@ GETRF_LAUNCHER_USM(std::complex<double>, rocsolver_zgetrf)
 
 #undef GETRF_LAUNCHER_USM
 
+#endif // ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS
+
 sycl::event getri(sycl::queue& queue, std::int64_t n, std::complex<float>* a, std::int64_t lda,
                   std::int64_t* ipiv, std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
@@ -1340,6 +1477,47 @@ sycl::event getri(sycl::queue& queue, std::int64_t n, std::complex<double>* a, s
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
     throw unimplemented("lapack", "getri");
 }
+
+#if ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS
+
+template <typename Func, typename T>
+inline sycl::event getrs(const char* func_name, Func func, sycl::queue& queue,
+                         oneapi::math::transpose trans, std::int64_t n, std::int64_t nrhs, T* a,
+                         std::int64_t lda, std::int64_t* ipiv, T* b, std::int64_t ldb,
+                         T* scratchpad, std::int64_t scratchpad_size,
+                         const std::vector<sycl::event>& dependencies) {
+    using rocmDataType = typename RocmEquivalentType<T>::Type;
+
+    return queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+        onemath_rocsolver_host_task(cgh, queue, [=](RocsolverScopedContextHandler& sc) {
+            auto handle = sc.get_handle(queue);
+            auto a_ = reinterpret_cast<rocmDataType*>(a);
+            auto b_ = reinterpret_cast<rocmDataType*>(b);
+            rocblas_status err;
+            rocsolver_native_named_func(func_name, func, err, handle, get_rocblas_operation(trans),
+                                        n, nrhs, a_, lda, ipiv, b_, ldb);
+        });
+    });
+}
+
+#define GETRS_LAUNCHER_USM(TYPE, ROCSOLVER_ROUTINE)                                              \
+    sycl::event getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n,         \
+                      std::int64_t nrhs, TYPE* a, std::int64_t lda, std::int64_t* ipiv, TYPE* b, \
+                      std::int64_t ldb, TYPE* scratchpad, std::int64_t scratchpad_size,          \
+                      const std::vector<sycl::event>& dependencies) {                            \
+        return getrs(#ROCSOLVER_ROUTINE, ROCSOLVER_ROUTINE, queue, trans, n, nrhs, a, lda, ipiv, \
+                     b, ldb, scratchpad, scratchpad_size, dependencies);                         \
+    }
+
+GETRS_LAUNCHER_USM(float, rocsolver_sgetrs_64)
+GETRS_LAUNCHER_USM(double, rocsolver_dgetrs_64)
+GETRS_LAUNCHER_USM(std::complex<float>, rocsolver_cgetrs_64)
+GETRS_LAUNCHER_USM(std::complex<double>, rocsolver_zgetrs_64)
+
+#undef GETRS_LAUNCHER_USM
+
+#else // no 64-bit pivot API: narrow the pivots into a temporary 32-bit array
 
 template <typename Func, typename T>
 inline sycl::event getrs(const char* func_name, Func func, sycl::queue& queue,
@@ -1401,6 +1579,8 @@ GETRS_LAUNCHER_USM(std::complex<float>, rocsolver_cgetrs)
 GETRS_LAUNCHER_USM(std::complex<double>, rocsolver_zgetrs)
 
 #undef GETRS_LAUNCHER_USM
+
+#endif // ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS
 
 template <typename Func, typename T_A, typename T_B>
 inline sycl::event gesvd(const char* func_name, Func func, sycl::queue& queue,


### PR DESCRIPTION
## Summary

The rocSOLVER counterpart of #759, which does the same for cuSOLVER (#230).

oneMath types `ipiv` as `int64_t`, while the legacy rocSOLVER entry points take `rocblas_int`. `getrf` and `getrs` therefore each allocated a temporary 32-bit array and ran a cast kernel around the call, and in the USM `getrs` that temporary also forced a `queue.wait()` before it could be released.

rocSOLVER has accepted `int64_t` pivots since 3.26 (ROCm 6.2), so both routines now pass the user's `ipiv` straight through. That removes four temporary allocations, their cast kernels and the blocking wait. The 64-bit `getrf` reports `info` as `int64_t` rather than `int`, so `get_rocsolver_devinfo` and `lapack_info_check` are templated on the info type. `ONEMATH_ROCSOLVER_HAS_64BIT_PIVOTS` keeps the previous conversion path for rocSOLVER older than 3.26, so the minimum supported ROCm is unchanged.

Because the 64-bit entry points take the dimensions as `int64_t`, `getrf` and `getrs` no longer need the `overflow_check` that rejected sizes above the 32-bit limit.

### Scope, and how this differs from #759

rocSOLVER has no `sytrf_64`, and `getri` and the `getrf_batch`, `getrs_batch` and `getri_batch` variants are `unimplemented` in this backend, so `getrf` and `getrs` are the only routines affected. There is nothing here matching #759's scratchpad-tail change, and `sytrf` keeps its existing conversion path.

As in #759, this reduces synchronization without making the USM paths fully asynchronous: `getrf` still blocks in `lapack_info_check`, which is pre-existing behaviour shared by the rest of the backend and left for separate work.

### Upstream rocBLAS dependency above 2^28 rows

The API now accepts dimensions past 2^31, but actually factorizing a matrix with more than 2^28 rows also needs the rocBLAS fix from ROCm/rocm-libraries#10831, which I filed while testing this. `rocblas_internal_scal_launcher_64` advances the alpha scalar pointer once per n-chunk, so `getrf_64` either faults with `hipErrorIllegalAddress` or returns a silently wrong factorization for any column longer than 2^28.

This is not a regression introduced here: it affects every rocSOLVER release that has the 64-bit API (verified on 6.2.4, 6.3.4, 6.4.4, 7.0.1, 7.1.1, 7.2.0 and 7.2.4), the fix is one line in rocBLAS, and nothing at or below 2^28 rows is affected. Reviewers should just know that the "dimensions beyond 2^31" part of this change is not usable until that fix lands. I am happy to gate the 64-bit path on a fixed rocBLAS version, or to cap rows at 2^28 with the legacy path above it, if you would prefer this not to advertise a size range that upstream cannot yet deliver.

## Test plan

Built against ROCm 7.2.4 with DPC++ and tested on an AMD Instinct MI300A (gfx942).

- [x] Functional LAPACK tests, both compile-time and run-time dispatch: 204 passed, 0 failed, 364 skipped, with identical results in both modes. Baseline `develop` on the same machine gives 180 passed, 0 failed, 364 skipped. The skips are the batch variants this backend does not implement.
- [x] The 24 newly passing tests are the `Getrf` and `Getrs` accuracy and dependency suites for all four types in buffer and USM form. To be precise about why they were not passing before: this DPC++ build trips a pre-existing assertion (`It != m_DeviceKernelInfoMap.end()`) on kernels compiled into a backend shared library, which the legacy path's cast kernels hit and the 64-bit path avoids by launching no kernels at all. On a toolchain without that problem both paths pass, so this is not a correctness change — the routines are simply now exercised locally.
- [x] Three `Sytrf` suites still abort from that same pre-existing assertion, unchanged from baseline; `sytrf` is untouched by this PR.
- [x] `int64_t` pivots verified end to end at `m = 2^31 + 1024` (8 GiB, `n = 1`, largest entry at row `m - 512`): `ipiv[0] = 2147484161`, which is 514 past `INT32_MAX` and would have truncated to `-2147483135` in the old 32-bit array. `a[0]` and the scaled column are correct. This run needs ROCm/rocm-libraries#10831; I validated it with that one-line fix applied at runtime through an `LD_PRELOAD` shim, cross-checked by confirming the shim also makes a standalone rocBLAS reproducer of the bug pass.
- [x] Version-guarded fallback compile-checked against real headers for rocSOLVER 3.24 (ROCm 6.0.3, legacy conversion path) and 3.26 through 3.32 (ROCm 6.2.4, 6.3.4, 6.4.4, 7.0.1, 7.1.1, 7.2.0, 7.2.4).
- [x] `clang-format` clean against the repository's `_clang-format`.
