### PR TITLE
[blas][rocblas] Restore the pointer mode when a rocBLAS call throws

### DIFF
--- a/src/blas/backends/rocblas/rocblas_helper.hpp
+++ b/src/blas/backends/rocblas/rocblas_helper.hpp
@@ -173,6 +173,30 @@ public:
     hipError_t hip_err;                                                    \
     HIP_ERROR_FUNC(hipStreamSynchronize, hip_err, currentStreamId);
 
+// Sets the pointer mode of a rocBLAS handle and restores the previous mode on scope
+// exit. rocBLAS handles are cached and reused across calls, so an unwound scope must
+// not leave the handle in device mode: later routines pass host addresses for their
+// scalar arguments and rocBLAS would dereference them on the device.
+class rocblas_pointer_mode_guard {
+    rocblas_handle handle_;
+    rocblas_pointer_mode previous_;
+
+public:
+    rocblas_pointer_mode_guard(rocblas_handle handle, rocblas_pointer_mode mode)
+            : handle_(handle),
+              previous_(rocblas_pointer_mode_host) {
+        rocblas_get_pointer_mode(handle_, &previous_);
+        rocblas_set_pointer_mode(handle_, mode);
+    }
+
+    ~rocblas_pointer_mode_guard() {
+        rocblas_set_pointer_mode(handle_, previous_);
+    }
+
+    rocblas_pointer_mode_guard(const rocblas_pointer_mode_guard&) = delete;
+    rocblas_pointer_mode_guard& operator=(const rocblas_pointer_mode_guard&) = delete;
+};
+
 template <class Func, class... Types>
 inline void rocblas_native_func(Func func, rocblas_status err, rocblas_handle handle,
                                 Types... args) {

--- a/src/blas/backends/rocblas/rocblas_helper.hpp
+++ b/src/blas/backends/rocblas/rocblas_helper.hpp
@@ -177,6 +177,13 @@ public:
 // exit. rocBLAS handles are cached and reused across calls, so an unwound scope must
 // not leave the handle in device mode: later routines pass host addresses for their
 // scalar arguments and rocBLAS would dereference them on the device.
+//
+// Note this restores whatever mode was in effect on entry, rather than unconditionally
+// forcing host mode as the manual set/reset pairs it replaces used to. That is correct
+// as long as every call site goes through this guard, but it does drop the old code's
+// incidental self-healing: if some other, unguarded path ever left a handle in device
+// mode, the previous code would have normalized it back to host on the next guarded
+// call, whereas this guard simply propagates the leaked mode.
 class rocblas_pointer_mode_guard {
     rocblas_handle handle_;
     rocblas_pointer_mode previous_;
@@ -185,10 +192,12 @@ public:
     rocblas_pointer_mode_guard(rocblas_handle handle, rocblas_pointer_mode mode)
             : handle_(handle),
               previous_(rocblas_pointer_mode_host) {
-        rocblas_get_pointer_mode(handle_, &previous_);
-        rocblas_set_pointer_mode(handle_, mode);
+        rocblas_status err;
+        ROCBLAS_ERROR_FUNC(rocblas_get_pointer_mode, err, handle_, &previous_);
+        ROCBLAS_ERROR_FUNC(rocblas_set_pointer_mode, err, handle_, mode);
     }
 
+    // Not ROCBLAS_ERROR_FUNC: destructors must not throw, so the restore is best-effort.
     ~rocblas_pointer_mode_guard() {
         rocblas_set_pointer_mode(handle_, previous_);
     }

--- a/src/blas/backends/rocblas/rocblas_level1.cpp
+++ b/src/blas/backends/rocblas/rocblas_level1.cpp
@@ -50,16 +50,12 @@ inline void asum(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T1, 1>& 
             // rocblas_set_pointer_mode mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto x_ = sc.get_mem<rocDataType1*>(x_acc);
             auto res_ = sc.get_mem<rocDataType2*>(res_acc);
             rocblas_status err;
             // ASUM does not support negative index
             rocblas_native_func(func, err, handle, n, x_, std::abs(incx), res_);
-            // Higher level BLAS functions expect rocblas_pointer_mode_host
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid invalid memory accesses
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 }
@@ -183,17 +179,13 @@ inline void rotg(Func func, sycl::queue& queue, sycl::buffer<T1, 1>& a, sycl::bu
             // rocblas_set_pointer_mode mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto a_ = sc.get_mem<rocDataType1*>(a_acc);
             auto b_ = sc.get_mem<rocDataType1*>(b_acc);
             auto c_ = sc.get_mem<rocDataType2*>(c_acc);
             auto s_ = sc.get_mem<rocDataType1*>(s_acc);
             rocblas_status err;
             rocblas_native_func(func, err, handle, a_, b_, c_, s_);
-            // Higher level BLAS functions expect rocblas_pointer_mode_host
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid invalid memory accesses
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 }
@@ -229,16 +221,12 @@ inline void rotm(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x
             // rocblas_set_pointer_mode mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto x_ = sc.get_mem<rocDataType*>(x_acc);
             auto y_ = sc.get_mem<rocDataType*>(y_acc);
             auto param_ = sc.get_mem<rocDataType*>(param_acc);
             rocblas_status err;
             rocblas_native_func(func, err, handle, n, x_, incx, y_, incy, param_);
-            // Higher level BLAS functions expect rocblas_pointer_mode_host
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid invalid memory accesses
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 }
@@ -305,16 +293,12 @@ inline void dot(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x,
             // rocblas_set_pointer_mode mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto x_ = sc.get_mem<rocDataType*>(x_acc);
             auto y_ = sc.get_mem<rocDataType*>(y_acc);
             auto res_ = sc.get_mem<rocDataType*>(res_acc);
             rocblas_status err;
             rocblas_native_func(func, err, handle, n, x_, incx, y_, incy, res_);
-            // Higher level BLAS functions expect rocblas_pointer_mode_host
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid invalid memory accesses
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 }
@@ -397,16 +381,12 @@ void sdsdot(sycl::queue& queue, int64_t n, float sb, sycl::buffer<float, 1>& x, 
             // rocblas_set_pointer_mode mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto x_ = sc.get_mem<float*>(x_acc);
             auto y_ = sc.get_mem<float*>(y_acc);
             auto res_ = sc.get_mem<float*>(res_acc);
             rocblas_status err;
             rocblas_native_func(rocblas_sdot, err, handle, n, x_, incx, y_, incy, res_);
-            // Higher level BLAS functions expect rocblas_pointer_mode_host
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid invalid memory accesses
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 
@@ -435,7 +415,7 @@ inline void rotmg(Func func, sycl::queue& queue, sycl::buffer<T, 1>& d1, sycl::b
             // rocblas_set_pointer_mode mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto d1_ = sc.get_mem<rocDataType*>(d1_acc);
             auto d2_ = sc.get_mem<rocDataType*>(d2_acc);
             auto x1_ = sc.get_mem<rocDataType*>(x1_acc);
@@ -443,10 +423,6 @@ inline void rotmg(Func func, sycl::queue& queue, sycl::buffer<T, 1>& d1, sycl::b
             auto param_ = sc.get_mem<rocDataType*>(param_acc);
             rocblas_status err;
             rocblas_native_func(func, err, handle, d1_, d2_, x1_, y1_, param_);
-            // Higher level BLAS functions expect rocblas_pointer_mode_host
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid invalid memory accesses
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 }
@@ -488,17 +464,13 @@ inline void iamax(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& 
             // rocblas_set_pointer_mode mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto x_ = sc.get_mem<rocDataType*>(x_acc);
             auto int_res_ = sc.get_mem<int*>(int_res_acc);
             rocblas_status err;
             // For negative incx, iamax returns 0. This behaviour is similar to that of
             // reference netlib BLAS.
             rocblas_native_func(func, err, handle, n, x_, incx, int_res_);
-            // Higher level BLAS functions expect rocblas_pointer_mode_host
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid invalid memory accesses
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 
@@ -585,17 +557,13 @@ inline void iamin(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& 
             // rocblas_set_pointer_mode mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto x_ = sc.get_mem<rocDataType*>(x_acc);
             auto int_res_ = sc.get_mem<int*>(int_res_acc);
             rocblas_status err;
             // For negative incx, iamin returns 0. This behaviour is similar to that of
             // implemented as a reference IAMIN.
             rocblas_native_func(func, err, handle, n, x_, incx, int_res_);
-            // Higher level BLAS functions expect rocblas_pointer_mode_host
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid invalid memory accesses
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 
@@ -641,16 +609,12 @@ inline void nrm2(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T1, 1>& 
             // rocblas_set_pointer_mode mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto x_ = sc.get_mem<rocDataType1*>(x_acc);
             auto res_ = sc.get_mem<rocDataType2*>(res_acc);
             rocblas_status err;
             // NRM2 does not support negative index
             rocblas_native_func(func, err, handle, n, x_, std::abs(incx), res_);
-            // Higher level BLAS functions expect rocblas_pointer_mode_host
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid invalid memory accesses
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 }
@@ -681,14 +645,13 @@ inline sycl::event asum(Func func, sycl::queue& queue, int64_t n, const T1* x, c
         cgh.depends_on(dependencies);
         onemath_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler& sc) {
             auto handle = sc.get_handle(queue);
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
 
             auto x_ = reinterpret_cast<const rocDataType1*>(x);
             auto res_ = reinterpret_cast<rocDataType2*>(result);
             rocblas_status err;
             // ASUM does not support negative index
             rocblas_native_func(func, err, handle, n, x_, std::abs(incx), res_);
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 
@@ -1065,14 +1028,13 @@ inline sycl::event iamax(Func func, sycl::queue& queue, int64_t n, const T* x, c
         cgh.depends_on(dependencies);
         onemath_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler& sc) {
             auto handle = sc.get_handle(queue);
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
             auto x_ = reinterpret_cast<const rocDataType*>(x);
             auto int_res_p_ = reinterpret_cast<int*>(int_res_p);
             rocblas_status err;
             // For negative incx, iamax returns 0. This behaviour is similar to that of
             // reference iamax.
             rocblas_native_func(func, err, handle, n, x_, incx, int_res_p_);
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 
@@ -1149,7 +1111,7 @@ inline sycl::event iamin(Func func, sycl::queue& queue, int64_t n, const T* x, c
         cgh.depends_on(dependencies);
         onemath_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler& sc) {
             auto handle = sc.get_handle(queue);
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
 
             auto x_ = reinterpret_cast<const rocDataType*>(x);
             auto int_res_p_ = reinterpret_cast<int*>(int_res_p);
@@ -1157,7 +1119,6 @@ inline sycl::event iamin(Func func, sycl::queue& queue, int64_t n, const T* x, c
             // For negative incx, iamin returns 0. This behaviour is similar to that of
             // implemented iamin.
             rocblas_native_func(func, err, handle, n, x_, incx, int_res_p_);
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 
@@ -1192,14 +1153,13 @@ inline sycl::event nrm2(Func func, sycl::queue& queue, int64_t n, const T1* x, c
         cgh.depends_on(dependencies);
         onemath_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler& sc) {
             auto handle = sc.get_handle(queue);
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
+            rocblas_pointer_mode_guard pointer_mode_guard(handle, rocblas_pointer_mode_device);
 
             auto x_ = reinterpret_cast<const rocDataType1*>(x);
             auto res_ = reinterpret_cast<rocDataType2*>(result);
             rocblas_status err;
             // NRM2 does not support negative index
             rocblas_native_func(func, err, handle, n, x_, std::abs(incx), res_);
-            rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes the pointer-mode leak that can produce the intermittent `RotTests.RealSinglePrecision` failure reported in #486.

The reduction routines (`asum`, `nrm2`, `dot`, `dotc`, `dotu`, `rotg`, `rotm`, `rotmg`, `iamax`, `iamin`) switch the rocBLAS handle to device pointer mode and switch it back after the call:

```cpp
rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
...
rocblas_native_func(func, err, handle, n, x_, std::abs(incx), res_);
rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
```

`rocblas_native_func` throws a `rocblas_error` on any status other than `rocblas_status_success`, so the reset is skipped. Handles are cached in thread-local storage and reused, so the handle stays in device pointer mode for every subsequent call on that thread.

Routines that pass a **host** address for their scalar arguments then have that address dereferenced on the device. `rot` is the most exposed one — it forwards `(rocDataType2*)&c` and `(rocDataType3*)&s` and never sets the pointer mode itself, relying entirely on the handle already being in host mode. On a discrete GPU, where host memory is not device-addressable, that is an illegal address.

This replaces the manual set/reset pairs at all 13 sites with an RAII guard, so the mode is restored during stack unwinding as well as on the normal path. The guard restores the *previous* mode rather than unconditionally forcing host mode, so it is safe to nest.

## Validation

On an AMD Instinct MI210 (gfx90a, ROCm 7.1.1, DPC++), provoking a failure inside a guarded region and then calling `rot`:

| | crashes |
|---|---|
| without the guard | 10 / 10 |
| with the guard | 0 / 10 |

Without the guard the `rot` call fails with `hipErrorIllegalAddress` (700) and leaves the queue unrecoverable. With it, `rot` returns correct results and a following `asum` is correct. Both arms take the identical first exception on the same queue, so the guard is the only difference.

Reproducer:

```cpp
// step 1: provoke a failure inside a pointer-mode-guarded region
try {
    oneapi::math::blas::column_major::asum(q, n, x, 1, (float*)nullptr).wait();
} catch (const std::exception& e) { /* expected */ }

// step 2: rot passes &c and &s, which are host addresses
const float c = 1.0f, s = 0.0f;          // identity rotation
oneapi::math::blas::column_major::rot(q, n, x, 1, y, 1, c, s).wait();
```

Also ran the BLAS test suite on the same MI210 with the fix applied: 740 tests pass with no failures.

## Caveats

- The reproducer forces the initial rocBLAS failure with a null result pointer. This change explains the cascade *given* that some earlier reduction call failed; it does not identify what failed first in the CI run behind #486.
- #486 was reported with AdaptiveCpp, which surfaces the fault as `HSA_STATUS_ERROR_INVALID_PACKET_FORMAT`. I could only verify with DPC++, which reports the same underlying invalid device address as `hipErrorIllegalAddress`. AdaptiveCpp was not available on the machine used.

## Test plan

- [x] Builds against `develop` with the rocBLAS backend (gfx90a, ROCm 7.1.1)
- [x] Deterministic MI210 reproducer passes with the fix and fails without it
- [x] BLAS functional tests pass on MI210 (740 passed, 0 failed)
- [ ] Confirmation on MI210 with AdaptiveCpp, matching the exact error in #486

Made with [Cursor](https://cursor.com)