### PR TITLE
[blas][rocblas] Take the HIP stream from the interop handle

### DIFF
--- a/src/blas/backends/rocblas/rocblas_scope_handle.cpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle.cpp
@@ -155,7 +155,10 @@ rocblas_handle RocblasScopedContextHandler::get_handle(const sycl::queue& queue)
 }
 
 hipStream_t RocblasScopedContextHandler::get_stream(const sycl::queue& queue) {
-    return sycl::get_native<sycl::backend::ext_oneapi_hip>(queue);
+    // The stream must come from the interop handle rather than from the queue:
+    // a queue owns a pool of streams and only the one the command was scheduled
+    // on is tracked by the SYCL event that gates this command's completion.
+    return interop_h.get_native_queue<sycl::backend::ext_oneapi_hip>();
 }
 sycl::context RocblasScopedContextHandler::get_context(const sycl::queue& queue) {
     return queue.get_context();


### PR DESCRIPTION
## Summary

`RocblasScopedContextHandler::get_stream` currently asks the queue for a native stream:

```cpp
return sycl::get_native<sycl::backend::ext_oneapi_hip>(queue);
```

A SYCL queue owns a pool of HIP streams, so the stream this returns is not necessarily the one the enqueued native command was scheduled on — and only the scheduled stream is covered by the SYCL event that gates the command's completion. Work submitted to a different stream would not be ordered by that event.

The interop handle knows the stream the command was actually scheduled on, so this takes it from there. That matches what the cuBLAS backend already does:

```cpp
// src/blas/backends/cublas/cublas_scope_handle.cpp
return ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
```

and what the AdaptiveCpp build of this same backend does:

```cpp
// src/blas/backends/rocblas/rocblas_scope_handle_adaptivecpp.cpp
return interop_h.get_native_queue<sycl::backend::hip>();
```

so this makes the DPC++ path consistent with both.

## Caveat

This is a consistency fix found while investigating #486, not a fix for an observed failure. I could not measure any behavioural difference from it on the hardware available (MI210 and MI300A) — the mismatch appears to be latent in practice, presumably because the pool commonly hands back the same stream. I am raising it separately from the #486 fix for that reason.

## Test plan

- [x] Builds against `develop` with the rocBLAS backend (gfx90a, ROCm 7.1.1)
- [x] BLAS functional tests pass on an AMD Instinct MI210

Made with [Cursor](https://cursor.com)